### PR TITLE
Cassandra settings improvements.

### DIFF
--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -1,6 +1,9 @@
+################################################################################
+############################### Operator settings ##############################
+################################################################################
+
 NODE_COUNT:
-  description: "Number of Cassandra nodes"
-  displayName: "Node Count"
+  description: "Number of Cassandra nodes."
   default: 3
 
 NODE_CPU_MC:
@@ -23,9 +26,17 @@ NODE_DISK_SIZE_GIB:
   description: "Disk size (in GiB) for the Cassandra node pods."
   default: 20
 
+NODE_STORAGE_CLASS:
+  description: "The storage class to be used in volumeClaimTemplates. By default its not required and the default storage class is used."
+  required: false
+
 OVERRIDE_CLUSTER_NAME:
   description: "Override the name of the Cassandra cluster set by the operator. This shouldn't be explicit set, unless you know what you're doing."
   default: ""
+
+################################################################################
+########################### Cassandra node settings ############################
+################################################################################
 
 STORAGE_PORT:
   description: "The port for inter-node communication."
@@ -47,13 +58,6 @@ JMX_PORT:
   description: "The JMX port that will be used to interface with the Cassandra application."
   default: "7199"
 
-STORAGE_CLASS:
-  description: "The storage class to be used in volumeClaimTemplates. By default its not required and the default storage class is used."
-  required: false
-
-PERSISTENT_STORAGE:
-  description: "If false, ephemeral storage is used. Not recommended for production use."
-  default: "true"
 NODE_MIN_HEAP_SIZE_MB:
   description: "The minimum JVM heap size in MB. This has a smart default and doesn't need to be explicitly set."
   default:
@@ -304,7 +308,7 @@ MEMTABLE_OFFHEAP_SPACE_IN_MB:
 
 MEMTABLE_CLEANUP_THRESHOLD:
   description: "The ratio used for automatic memtable flush"
-  default: 
+  default:
 
 MEMTABLE_FLUSH_WRITERS:
   description: "The number of memtable flush writer threads"
@@ -539,7 +543,7 @@ ALLOCATE_TOKENS_FOR_KEYSPACE:
   default: ""
 
 INITIAL_TOKEN:
-  description: "initial_token allows you to specify tokens manually."
+  description: "Allows the token to be specified manually."
   default:
 
 HINTS_DIRECTORY:
@@ -586,10 +590,10 @@ OTC_BACKLOG_EXPIRATION_INTERVAL_MS:
   description: "How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection."
   default:
 
+################################################################################
+################################ JVM Options ###################################
+################################################################################
 
-################################################################################
-############################ JVM OPTIONS #######################################
-################################################################################
 JVM_OPT_AVAILABLE_PROCESSORS:
   description: "In a multi-instance deployment, multiple Cassandra instances will independently assume that all CPU processors are available to it. This setting allows you to specify a smaller set of processors and perhaps have affinity."
   default:

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -642,7 +642,7 @@ JVM_OPT_THREAD_PRIORITY_POLICY:
   description: "allows lowering thread priority without being root on linux - probably not necessary on Windows but doesn't harm anything."
   default: 42
 
-JVM_OPT_PER_THREAD_STACK_SIZE:
+JVM_OPT_THREAD_STACK_SIZE:
   description: "Per-thread stack size."
   default: "256k"
 

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -27,7 +27,7 @@ NODE_DISK_SIZE_GIB:
   default: 20
 
 NODE_STORAGE_CLASS:
-  description: "The storage class to be used in volumeClaimTemplates. By default its not required and the default storage class is used."
+  description: "The storage class to be used in volumeClaimTemplates. By default, it is not required and the default storage class is used."
   required: false
 
 OVERRIDE_CLUSTER_NAME:

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -23,6 +23,10 @@ NODE_DISK_SIZE_GIB:
   description: "Disk size (in GiB) for the Cassandra node pods."
   default: 20
 
+OVERRIDE_CLUSTER_NAME:
+  description: "Override the name of the Cassandra cluster set by the operator. This shouldn't be explicit set, unless you know what you're doing."
+  default: ""
+
 STORAGE_PORT:
   description: "The port for inter-node communication."
   default: "7000"
@@ -50,10 +54,6 @@ STORAGE_CLASS:
 PERSISTENT_STORAGE:
   description: "If false, ephemeral storage is used. Not recommended for production use."
   default: "true"
-
-CLUSTER_NAME:
-  description: "The name of the cluster managed by the Service"
-  default: ""
 NODE_MIN_HEAP_SIZE_MB:
   description: "The minimum JVM heap size in MB. This has a smart default and doesn't need to be explicitly set."
   default:

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -522,19 +522,19 @@ BACK_PRESSURE_ENABLED:
   description: "Enable for the coordinator to apply the specified back pressure strategy to each mutation that is sent to replicas."
   default: false
 
-BACK_PRESSURE_STRATEGY_CLASS:
+BACK_PRESSURE_STRATEGY_CLASS_NAME:
   description: "The back-pressure strategy applied. The default implementation, RateBasedBackPressure, takes three arguments: high ratio, factor, and flow type, and uses the ratio between incoming mutation responses and outgoing mutation requests."
   default: "org.apache.cassandra.net.RateBasedBackPressure"
 
-BACK_PRESSURE_HIGH_RATIO:
+BACK_PRESSURE_STRATEGY_HIGH_RATIO:
   description: "When outgoing mutations are below this value, they are rate limited according to the incoming rate decreased by the factor. When above this value, the rate limiting is increased by the factor."
   default: 0.9
 
-BACK_PRESSURE_FACTOR:
+BACK_PRESSURE_STRATEGY_FACTOR:
   description: "A number between 1 and 10. Increases or decreases rate limiting."
   default: 5
 
-BACK_PRESSURE_FLOW:
+BACK_PRESSURE_STRATEGY_FLOW:
   description: "The flow speed to apply rate limiting: FAST - rate limited to the speed of the fastest replica. SLOW - rate limit to the speed of the slowest replica."
   default: "FAST"
 

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -542,10 +542,6 @@ ALLOCATE_TOKENS_FOR_KEYSPACE:
   description: "Triggers automatic allocation of num_tokens tokens for this node. The allocation algorithm attempts to choose tokens in a way that optimizes replicated load over the nodes in the datacenter for the replication strategy used by the specified keyspace."
   default: ""
 
-INITIAL_TOKEN:
-  description: "Allows the token to be specified manually."
-  default:
-
 HINTS_DIRECTORY:
   description: "Directory where Cassandra should store hints."
   default: ""

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -3,21 +3,25 @@ NODE_COUNT:
   displayName: "Node Count"
   default: 3
 
-NODE_CPUS:
-  description: "CPUs (request) for the Cassandra node pods. spec.containers[].resources.requests.cpu"
-  default: "2000m"
+NODE_CPU_MC:
+  description: "CPU request (in millicores) for the Cassandra node pods."
+  default: 2000
 
-NODE_CPUS_LIMIT:
-  description: "CPUs (limit) for the Cassandra node pods. spec.containers[].resources.limits.cpu"
-  default: "2000m"
+NODE_CPU_LIMIT_MC:
+  description: "CPU limit (in millicores) for the Cassandra node pods."
+  default: 2000
 
-NODE_MEM:
-  description: "Memory (request) for the Cassandra node pods. spec.containers[].resources.requests.memory"
+NODE_MEM_MIB:
+  description: "Memory request (in MiB) for the Cassandra node pods."
   default: 4096
 
-NODE_MEM_LIMIT:
-  description: "Memory (limit) for the Cassandra node pods. spec.containers[].resources.limits.memory"
+NODE_MEM_LIMIT_MIB:
+  description: "Memory limit (in MiB) for the Cassandra node pods."
   default: 4096
+
+NODE_DISK_SIZE_GIB:
+  description: "Disk size (in GiB) for the Cassandra node pods."
+  default: 20
 
 STORAGE_PORT:
   description: "The port for inter-node communication."
@@ -39,10 +43,6 @@ JMX_PORT:
   description: "The JMX port that will be used to interface with the Cassandra application."
   default: "7199"
 
-DISK_SIZE:
-  description: "Disk size for the nodes"
-  default: "20Gi"
-
 STORAGE_CLASS:
   description: "The storage class to be used in volumeClaimTemplates. By default its not required and the default storage class is used."
   required: false
@@ -54,13 +54,16 @@ PERSISTENT_STORAGE:
 CLUSTER_NAME:
   description: "The name of the cluster managed by the Service"
   default: ""
-
-CASSANDRA_HEAP_SIZE_MB:
-  description: "The amount of JVM heap, in MB, allocated to the Cassandra process."
+NODE_MIN_HEAP_SIZE_MB:
+  description: "The minimum JVM heap size in MB. This has a smart default and doesn't need to be explicitly set."
   default:
 
-CASSANDRA_HEAP_NEW_MB:
-  description: "The amount of JVM new generation heap, in MB, allocated to the Cassandra process."
+NODE_MAX_HEAP_SIZE_MB:
+  description: "The maximum JVM heap size in MB. This has a smart default and doesn't need to be explicitly set."
+  default:
+
+NODE_NEW_GENERATION_HEAP_SIZE_MB:
+  description: "The JVM new generation heap size in MB."
   default:
 
 SEED_PROVIDER_CLASS:

--- a/operator/templates/cassandra-yaml.yaml
+++ b/operator/templates/cassandra-yaml.yaml
@@ -53,9 +53,13 @@ data:
     # vnodes (num_tokens > 1, above) -- in which case you should provide a
     # comma-separated list -- it's primarily used when adding nodes to legacy clusters
     # that do not have vnodes enabled.
-    {{ if .Params.INITIAL_TOKEN }}
-    initial_token: {{ .Params.INITIAL_TOKEN }}
-    {{ end }}
+    #
+    # NOTE(mpereira): "initial_token" should be set on a per-node basis, so it
+    # doesn't make sense to expose it as an operator setting. Maybe we'll
+    # somehow support this more officially in the future. For now we'll leave it
+    # commented out.
+    #
+    # initial_token: ...
 
     # See http://wiki.apache.org/cassandra/HintedHandoff
     # May either be "true" or "false" to enable globally

--- a/operator/templates/cassandra-yaml.yaml
+++ b/operator/templates/cassandra-yaml.yaml
@@ -13,9 +13,11 @@ data:
 
     # The name of the cluster. This is mainly used to prevent machines in
     # one logical cluster from joining another.
-    {{ if .Params.CLUSTER_NAME }}    
-    cluster_name: '{{ .Params.CLUSTER_NAME }}'
-    {{ else }}    
+    {{ if .Params.OVERRIDE_CLUSTER_NAME }}
+    cluster_name: '{{ .Params.OVERRIDE_CLUSTER_NAME }}'
+    {{ else }}
+    # TODO(mpereira): does it make sense to prepend the Kubernetes namespace to
+    # the Cassandra cluster name?
     cluster_name: '{{ .Name }}'
     {{ end }}
 

--- a/operator/templates/cassandra-yaml.yaml
+++ b/operator/templates/cassandra-yaml.yaml
@@ -63,14 +63,16 @@ data:
 
     # When hinted_handoff_enabled is true, a black list of data centers that will not
     # perform hinted handoff
+    #
+    # TODO(mpereira): expose this setting when we add multi-datacenter support.
     # hinted_handoff_disabled_datacenters:
-    #    - DC1
-    #    - DC2
+    #   - DC1
+    #   - DC2
 
     # this defines the maximum amount of time a dead host will have hints
     # generated.  After it has been dead this long, new hints for it will not be
     # created until it has been seen alive and gone down again.
-    max_hint_window_in_ms: {{ .Params.MAX_HINT_WINDOW_IN_MS }} # 3 hours
+    max_hint_window_in_ms: {{ .Params.MAX_HINT_WINDOW_IN_MS }}
 
     # Maximum throttle in KBs per second, per delivery thread.  This will be
     # reduced proportionally to the number of nodes in the cluster.  (If there
@@ -100,10 +102,10 @@ data:
     # Compression to apply to the hint files. If omitted, hints files
     # will be written uncompressed. LZ4, Snappy, and Deflate compressors
     # are supported.
-    #hints_compression:
+    # hints_compression:
     #   - class_name: LZ4Compressor
     #     parameters:
-    #         -
+    #       - ...
 
     # Maximum throttle in KBs per second, total. This will be
     # reduced proportionally to the number of nodes in the cluster.
@@ -339,11 +341,10 @@ data:
     #
     # org.apache.cassandra.cache.SerializingCacheProvider
     #   This is the row cache implementation availabile
-    #   in previous releases of Cassandra. 
+    #   in previous releases of Cassandra.
     {{ if .Params.ROW_CACHE_CLASS_NAME }}
     row_cache_class_name: {{ .Params.ROW_CACHE_CLASS_NAME }}
     {{ end }}
-
 
     # Maximum size of the row cache in memory.
     # Please note that OHC cache implementation requires some additional off-heap memory to manage
@@ -401,30 +402,27 @@ data:
 
     # saved caches
     # If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
-    # saved_caches_directory: /var/lib/cassandra/saved_caches    
+    # saved_caches_directory: /var/lib/cassandra/saved_caches
     {{ if .Params.SAVED_CACHES_DIRECTORY }}
     saved_caches_directory: {{ .Params.SAVED_CACHES_DIRECTORY }}
     {{ end }}
 
     # commitlog_sync may be either "periodic" or "batch."
     #
-    # When in batch mode, Cassandra won't ack writes until the commit log
-    # has been fsynced to disk.  It will wait
-    # commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
-    # This window should be kept short because the writer threads will
-    # be unable to do extra work while waiting.  (You may need to increase
-    # concurrent_writes for the same reason.)
+    # When in batch mode, Cassandra won't ack writes until the commit log has
+    # been fsynced to disk. It will wait commitlog_sync_batch_window_in_ms
+    # milliseconds between fsyncs. This window should be kept short because the
+    # writer threads will be unable to do extra work while waiting. (You may
+    # need to increase concurrent_writes for the same reason.)
     #
-    # commitlog_sync: batch
-    {{ if .Params.COMMITLOG_SYNC_BATCH_WINDOW_IN_MS }}
-    commitlog_sync_batch_window_in_ms: {{ .Params.COMMITLOG_SYNC_BATCH_WINDOW_IN_MS }}
-    {{ end }}
-    #
-    # the other option is "periodic" where writes may be acked immediately
-    # and the CommitLog is simply synced every commitlog_sync_period_in_ms
+    # the other option is "periodic" where writes may be acked immediately and
+    # the CommitLog is simply synced every commitlog_sync_period_in_ms
     # milliseconds.
     commitlog_sync: {{ .Params.COMMITLOG_SYNC }}
     commitlog_sync_period_in_ms: {{ .Params.COMMITLOG_SYNC_PERIOD_IN_MS }}
+    {{ if .Params.COMMITLOG_SYNC_BATCH_WINDOW_IN_MS }}
+    commitlog_sync_batch_window_in_ms: {{ .Params.COMMITLOG_SYNC_BATCH_WINDOW_IN_MS }}
+    {{ end }}
 
     # The size of the individual commitlog file segments.  A commitlog
     # segment may be archived, deleted, or recycled once all the data
@@ -450,25 +448,24 @@ data:
     # commitlog_compression:
     #   - class_name: LZ4Compressor
     #     parameters:
-    #         -
+    #       -
 
     # any class that implements the SeedProvider interface and has a
     # constructor that takes a Map<String, String> of parameters will do.
     seed_provider:
-        # Addresses of hosts that are deemed contact points.
-        # Cassandra nodes use this list of hosts to find each other and learn
-        # the topology of the ring.  You must change this if you are running
-        # multiple nodes!
-        - class_name: {{ .Params.SEED_PROVIDER_CLASS }}
-          parameters:
-              # Here we follow the advice from DataStax and make the first 3
-              # nodes in a DC the seed nodes.
-              # https://docs.datastax.com/en/dse/6.0/dse-admin/datastax_enterprise/production/seedNodesForSingleDC.html
-              - seeds: "{{- range $i, $node := until (int (min 3 .Params.NODE_COUNT)) -}}
-                          {{- if $i -}}, {{- end -}}
-                          {{ $.Name }}-node-{{ $node }}.{{ $.Name }}-svc.{{ $.Namespace }}.svc.cluster.local
-                        {{- end -}}"
-
+      # Addresses of hosts that are deemed contact points.
+      # Cassandra nodes use this list of hosts to find each other and learn
+      # the topology of the ring.  You must change this if you are running
+      # multiple nodes!
+      - class_name: {{ .Params.SEED_PROVIDER_CLASS }}
+        parameters:
+          # Here we follow the advice from DataStax and make the first 3
+          # nodes in a DC the seed nodes.
+          # https://docs.datastax.com/en/dse/6.0/dse-admin/datastax_enterprise/production/seedNodesForSingleDC.html
+          - seeds: "{{- range $i, $node := until (int (min 3 .Params.NODE_COUNT)) -}}
+                      {{- if $i -}}, {{- end -}}
+                      {{ $.Name }}-node-{{ $node }}.{{ $.Name }}-svc.{{ $.Namespace }}.svc.cluster.local
+                    {{- end -}}"
 
     # For workloads with more data than can fit in memory, Cassandra's
     # bottleneck will be reads that need to fetch data from
@@ -542,7 +539,6 @@ data:
     {{ if .Params.MEMTABLE_CLEANUP_THRESHOLD }}
     memtable_cleanup_threshold: {{ .Params.MEMTABLE_CLEANUP_THRESHOLD }}
     {{ end }}
-
 
     # Specify the way Cassandra allocates and manages memtable memory.
     # Options are:
@@ -800,7 +796,7 @@ data:
     # of an o.a.c.t.TServerFactory that can create an instance of it.
     rpc_server_type: {{ .Params.RPC_SERVER_TYPE }}
 
-    # Uncomment rpc_min|max_thread to set request pool size limits.
+    # Set request pool size limits.
     #
     # Regardless of your choice of RPC server (see above), the number of maximum requests in the
     # RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
@@ -813,19 +809,20 @@ data:
     {{ if .Params.RPC_MIN_THREADS }}
     rpc_min_threads: {{ .Params.RPC_MIN_THREADS }}
     {{ end }}
+
     {{ if .Params.RPC_MAX_THREADS }}
     rpc_max_threads: {{ .Params.RPC_MAX_THREADS }}
     {{ end }}
 
-    # uncomment to set socket buffer sizes on rpc connections
     {{ if .Params.RPC_SEND_BUFF_SIZE_IN_BYTES }}
     rpc_send_buff_size_in_bytes: {{ .Params.RPC_SEND_BUFF_SIZE_IN_BYTES }}
     {{ end }}
+
     {{ if .Params.RPC_RECV_BUFF_SIZE_IN_BYTES }}
-    rpc_recv_buff_size_in_bytes: {{ .Params.RPC_RECV_BUFF_SIZE_IN_BYTES }} 
+    rpc_recv_buff_size_in_bytes: {{ .Params.RPC_RECV_BUFF_SIZE_IN_BYTES }}
     {{ end }}
 
-    # Uncomment to set socket buffer size for internode communication
+    # Set socket buffer size for internode communication
     # Note that when setting this, the buffer size is limited by net.core.wmem_max
     # and when not setting it it is defined by net.ipv4.tcp_wmem
     # See also:
@@ -838,7 +835,7 @@ data:
     internode_send_buff_size_in_bytes: {{ .Params.INTERNODE_SEND_BUFF_SIZE_IN_BYTES }}
     {{ end }}
 
-    # Uncomment to set socket buffer size for internode communication
+    # Set socket buffer size for internode communication
     # Note that when setting this, the buffer size is limited by net.core.wmem_max
     # and when not setting it it is defined by net.ipv4.tcp_wmem
     {{ if .Params.INTERNODE_RECV_BUFF_SIZE_IN_BYTES }}
@@ -932,7 +929,7 @@ data:
     # this setting allows users to throttle inter dc stream throughput in addition
     # to throttling all network stream traffic as configured with
     # stream_throughput_outbound_megabits_per_sec
-    # When unset, the default is 200 Mbps or 25 MB/s    
+    # When unset, the default is 200 Mbps or 25 MB/s
     {{ if .Params.INTER_DC_STREAM_THROUGHPUT_OUTBOUND_MEGABITS_PER_SEC }}
     inter_dc_stream_throughput_outbound_megabits_per_sec: {{ .Params.INTER_DC_STREAM_THROUGHPUT_OUTBOUND_MEGABITS_PER_SEC }}
     {{ end }}
@@ -1131,36 +1128,39 @@ data:
     # the keystore and truststore.  For instructions on generating these files, see:
     # http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
     #
+    # TODO(mpereira): we'll have to configure this when adding TLS support.
     server_encryption_options:
-        internode_encryption: none
-        keystore: conf/.keystore
-        keystore_password: cassandra
-        truststore: conf/.truststore
-        truststore_password: cassandra
-        # More advanced defaults below:
-        # protocol: TLS
-        # algorithm: SunX509
-        # store_type: JKS
-        # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
-        # require_client_auth: false
-        # require_endpoint_verification: false
+      internode_encryption: none
+      keystore: conf/.keystore
+      keystore_password: cassandra
+      truststore: conf/.truststore
+      truststore_password: cassandra
+      # More advanced defaults below:
+      # protocol: TLS
+      # algorithm: SunX509
+      # store_type: JKS
+      # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+      # require_client_auth: false
+      # require_endpoint_verification: false
 
     # enable or disable client/server encryption.
+    #
+    # TODO(mpereira): we'll have to configure this when adding TLS support.
     client_encryption_options:
-        enabled: false
-        # If enabled and optional is set to true encrypted and unencrypted connections are handled.
-        optional: false
-        keystore: conf/.keystore
-        keystore_password: cassandra
-        # require_client_auth: false
-        # Set trustore and truststore_password if require_client_auth is true
-        # truststore: conf/.truststore
-        # truststore_password: cassandra
-        # More advanced defaults below:
-        # protocol: TLS
-        # algorithm: SunX509
-        # store_type: JKS
-        # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+      enabled: false
+      # If enabled and optional is set to true encrypted and unencrypted connections are handled.
+      optional: false
+      keystore: conf/.keystore
+      keystore_password: cassandra
+      # require_client_auth: false
+      # Set trustore and truststore_password if require_client_auth is true
+      # truststore: conf/.truststore
+      # truststore_password: cassandra
+      # More advanced defaults below:
+      # protocol: TLS
+      # algorithm: SunX509
+      # store_type: JKS
+      # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
 
     # internode_compression controls whether traffic between nodes is
     # compressed.
@@ -1215,7 +1215,6 @@ data:
     # setting.
     windows_timer_interval: {{ .Params.WINDOWS_TIMER_INTERVAL }}
 
-
     # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
     # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
     # the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
@@ -1229,20 +1228,19 @@ data:
     # Currently, only the following file types are supported for transparent data encryption, although
     # more are coming in future cassandra releases: commitlog, hints
     transparent_data_encryption_options:
-        enabled: false
-        chunk_length_kb: 64
-        cipher: AES/CBC/PKCS5Padding
-        key_alias: testing:1
-        # CBC IV length for AES needs to be 16 bytes (which is also the default size)
-        # iv_length: 16
-        key_provider:
-          - class_name: org.apache.cassandra.security.JKSKeyProvider
-            parameters:
-              - keystore: conf/.keystore
-                keystore_password: cassandra
-                store_type: JCEKS
-                key_password: cassandra
-
+      enabled: false
+      chunk_length_kb: 64
+      cipher: AES/CBC/PKCS5Padding
+      key_alias: testing:1
+      # CBC IV length for AES needs to be 16 bytes (which is also the default size)
+      # iv_length: 16
+      key_provider:
+        - class_name: org.apache.cassandra.security.JKSKeyProvider
+          parameters:
+            - keystore: conf/.keystore
+              keystore_password: cassandra
+              store_type: JCEKS
+              key_password: cassandra
 
     #####################
     # SAFETY THRESHOLDS #
@@ -1301,11 +1299,11 @@ data:
     # New strategies can be added. Implementors need to implement org.apache.cassandra.net.BackpressureStrategy and
     # provide a public constructor accepting a Map<String, Object>.
     back_pressure_strategy:
-        - class_name: {{ .Params.BACK_PRESSURE_STRATEGY_CLASS }}
-          parameters:
-            - high_ratio: {{ .Params.BACK_PRESSURE_HIGH_RATIO }}
-              factor: {{ .Params.BACK_PRESSURE_FACTOR }}
-              flow: {{ .Params.BACK_PRESSURE_FLOW }}
+      - class_name: {{ .Params.BACK_PRESSURE_STRATEGY_CLASS }}
+        parameters:
+          - high_ratio: {{ .Params.BACK_PRESSURE_HIGH_RATIO }}
+            factor: {{ .Params.BACK_PRESSURE_FACTOR }}
+            flow: {{ .Params.BACK_PRESSURE_FLOW }}
     # Coalescing Strategies #
     # Coalescing multiples messages turns out to significantly boost message processing throughput (think doubling or more).
     # On bare metal, the floor for packet processing throughput is high enough that many applications won't notice, but in

--- a/operator/templates/cassandra-yaml.yaml
+++ b/operator/templates/cassandra-yaml.yaml
@@ -1299,11 +1299,11 @@ data:
     # New strategies can be added. Implementors need to implement org.apache.cassandra.net.BackpressureStrategy and
     # provide a public constructor accepting a Map<String, Object>.
     back_pressure_strategy:
-      - class_name: {{ .Params.BACK_PRESSURE_STRATEGY_CLASS }}
+      - class_name: {{ .Params.BACK_PRESSURE_STRATEGY_CLASS_NAME }}
         parameters:
-          - high_ratio: {{ .Params.BACK_PRESSURE_HIGH_RATIO }}
-            factor: {{ .Params.BACK_PRESSURE_FACTOR }}
-            flow: {{ .Params.BACK_PRESSURE_FLOW }}
+          - high_ratio: {{ .Params.BACK_PRESSURE_STRATEGY_HIGH_RATIO }}
+            factor: {{ .Params.BACK_PRESSURE_STRATEGY_FACTOR }}
+            flow: {{ .Params.BACK_PRESSURE_STRATEGY_FLOW }}
     # Coalescing Strategies #
     # Coalescing multiples messages turns out to significantly boost message processing throughput (think doubling or more).
     # On bare metal, the floor for packet processing throughput is high enough that many applications won't notice, but in

--- a/operator/templates/jvm-options.yaml
+++ b/operator/templates/jvm-options.yaml
@@ -28,10 +28,10 @@ data:
     {{ end }}
 
     # The directory location of the cassandra.yaml file.
-    #-Dcassandra.config=directory
+    # -Dcassandra.config=directory
 
     # Sets the initial partitioner token for a node the first time the node is started.
-    #-Dcassandra.initial_token=token
+    # -Dcassandra.initial_token=token
 
     # Set to false to start Cassandra on a node but not have the node join the cluster.
     {{ if .Params.JVM_OPT_JOIN_RING }}
@@ -45,18 +45,23 @@ data:
     {{ end }}
 
     # Enable pluggable metrics reporter. See Pluggable metrics reporting in Cassandra 2.0.2.
-    #-Dcassandra.metricsReporterConfigFile=file
+    # -Dcassandra.metricsReporterConfigFile=file
 
     # Set the port on which the CQL native transport listens for clients. (Default: 9042)
-    #-Dcassandra.native_transport_port=port
+    # Overrides the value set in cassandra.yaml.
+    # -Dcassandra.native_transport_port=port
 
-    # Overrides the partitioner. (Default: org.apache.cassandra.dht.Murmur3Partitioner)
-    #-Dcassandra.partitioner=partitioner
+    # Overrides the value set in cassandra.yaml.
+    # (Default: org.apache.cassandra.dht.Murmur3Partitioner)
+    # -Dcassandra.partitioner=partitioner
 
     # To replace a node that has died, restart a new node in its place specifying the address of the
     # dead node. The new node must not have any data in its data directory, that is, it must be in the
     # same state as before bootstrapping.
-    #-Dcassandra.replace_address=listen_address or broadcast_address of dead node
+    #
+    # TODO(mpereira): we'll need to set this when replacing pods. Should we make
+    # it configurable via params.yaml too?
+    # -Dcassandra.replace_address=listen_address or broadcast_address of dead node
 
     # Allow restoring specific tables from an archived commit log.
     {{ if .Params.JVM_OPT_REPLAYLIST }}
@@ -70,19 +75,24 @@ data:
     {{ end }}
 
     # Set the port for the Thrift RPC service, which is used for client connections. (Default: 9160)
-    #-Dcassandra.rpc_port=port
+    # Overrides the value set in cassandra.yaml.
+    # -Dcassandra.rpc_port=port
 
     # Set the SSL port for encrypted communication. (Default: 7001)
-    #-Dcassandra.ssl_storage_port=port
+    # Overrides the value set in cassandra.yaml.
+    # -Dcassandra.ssl_storage_port=port
 
     # Enable or disable the native transport server. See start_native_transport in cassandra.yaml.
-    # cassandra.start_native_transport=true|false
+    # Overrides the value set in cassandra.yaml.
+    # -Dcassandra.start_native_transport=true|false
 
     # Enable or disable the Thrift RPC server. (Default: true)
-    #-Dcassandra.start_rpc=true/false
+    # Overrides the value set in cassandra.yaml.
+    # -Dcassandra.start_rpc=true/false
 
     # Set the port for inter-node communication. (Default: 7000)
-    #-Dcassandra.storage_port=port
+    # Overrides the value set in cassandra.yaml.
+    # -Dcassandra.storage_port=port
 
     # Set the default location for the trigger JARs. (Default: conf/triggers)
     {{ if .Params.JVM_OPT_TRIGGERS_DIR }}
@@ -159,15 +169,15 @@ data:
     ### Debug options
 
     # uncomment to enable flight recorder
-    #-XX:+UnlockCommercialFeatures
-    #-XX:+FlightRecorder
+    # -XX:+UnlockCommercialFeatures
+    # -XX:+FlightRecorder
 
     # uncomment to have Cassandra JVM listen for remote debuggers/profilers on port 1414
-    #-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1414
+    # -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1414
 
     # uncomment to have Cassandra JVM log internal method compilation (developers only)
-    #-XX:+UnlockDiagnosticVMOptions
-    #-XX:+LogCompilation
+    # -XX:+UnlockDiagnosticVMOptions
+    # -XX:+LogCompilation
 
     #################
     # HEAP SETTINGS #
@@ -242,19 +252,25 @@ data:
     -XX:+UseParNewGC
     -XX:+UseConcMarkSweepGC
     -XX:+CMSParallelRemarkEnabled
+
     {{ if .Params.JVM_OPT_SURVIVOR_RATIO }}
     -XX:SurvivorRatio={{ .Params.JVM_OPT_SURVIVOR_RATIO }}
     {{ end }}
+
     {{ if .Params.JVM_OPT_MAX_TENURING_THRESHOLD }}
     -XX:MaxTenuringThreshold={{ .Params.JVM_OPT_MAX_TENURING_THRESHOLD }}
     {{ end }}
+
     {{ if .Params.JVM_OPT_CMS_INITIATING_OCCUPANCY_FRACTION }}
     -XX:CMSInitiatingOccupancyFraction={{ .Params.JVM_OPT_CMS_INITIATING_OCCUPANCY_FRACTION }}
     {{ end }}
+
     -XX:+UseCMSInitiatingOccupancyOnly
+
     {{ if .Params.JVM_OPT_CMS_WAIT_DURATION }}
     -XX:CMSWaitDuration={{ .Params.JVM_OPT_CMS_WAIT_DURATION }}
     {{ end }}
+
     -XX:+CMSParallelInitialMarkEnabled
     -XX:+CMSEdenChunksRecordAlways
     # some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541
@@ -263,7 +279,7 @@ data:
     ### G1 Settings (experimental, comment previous section and uncomment section below to enable)
 
     ## Use the Hotspot garbage-first collector.
-    #-XX:+UseG1GC
+    # -XX:+UseG1GC
     #
     ## Have the JVM do less remembered set work during STW, instead
     ## preferring concurrent GC. Reduces p99.9 latency.
@@ -289,7 +305,7 @@ data:
     # For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
     # Otherwise equal to the number of cores when 8 or less.
     # Machines with > 10 cores should try setting these to <= full cores.
-    #-XX:ParallelGCThreads=16
+    # -XX:ParallelGCThreads=16
     # By default, ConcGCThreads is 1/4 of ParallelGCThreads.
     # Setting both to the same value can reduce STW durations.
     {{ if .Params.JVM_OPT_CONC_GC_THREADS }}
@@ -304,16 +320,21 @@ data:
     -XX:+PrintTenuringDistribution
     -XX:+PrintGCApplicationStoppedTime
     -XX:+PrintPromotionFailure
+
     {{ if .Params.JVM_OPT_PRINT_FLS_STATISTICS }}
     -XX:PrintFLSStatistics={{ .Params.JVM_OPT_PRINT_FLS_STATISTICS }}
     {{ end }}
+
     {{ if .Params.JVM_OPT_GC_LOG_DIRECTORY }}
     -Xloggc:{{ .Params.JVM_OPT_GC_LOG_DIRECTORY }}
     {{ end }}
+
     -XX:+UseGCLogFileRotation
+
     {{ if .Params.JVM_OPT_NUMBER_OF_GC_LOG_FILES }}
     -XX:NumberOfGCLogFiles={{ .Params.JVM_OPT_NUMBER_OF_GC_LOG_FILES }}
     {{ end }}
+
     {{ if .Params.JVM_OPT_GC_LOG_FILE_SIZE }}
     -XX:GCLogFileSize={{ .Params.JVM_OPT_GC_LOG_FILE_SIZE }}
     {{ end }}

--- a/operator/templates/jvm-options.yaml
+++ b/operator/templates/jvm-options.yaml
@@ -139,7 +139,7 @@ data:
     -XX:+HeapDumpOnOutOfMemoryError
 
     # Per-thread stack size.
-    -Xss{{ .Params.JVM_OPT_PER_THREAD_STACK_SIZE }}
+    -Xss{{ .Params.JVM_OPT_THREAD_STACK_SIZE }}
 
     # Larger interned string table, for gossip's benefit (CASSANDRA-6410)
     -XX:StringTableSize={{ .Params.JVM_OPT_STRING_TABLE_SIZE }}

--- a/operator/templates/jvm-options.yaml
+++ b/operator/templates/jvm-options.yaml
@@ -188,12 +188,16 @@ data:
     # the same value to avoid stop-the-world GC pauses during resize, and
     # so that we can lock the heap in memory on startup to prevent any
     # of it from being swapped out.
-    {{ if .Params.CASSANDRA_HEAP_SIZE_MB }}
-    -Xms{{ .Params.CASSANDRA_HEAP_SIZE_MB }}M
-    -Xmx{{ .Params.CASSANDRA_HEAP_SIZE_MB }}M
+    {{ if .Params.NODE_MIN_HEAP_SIZE_MB }}
+    -Xms{{ .Params.NODE_MIN_HEAP_SIZE_MB }}M
     {{ else }}
-    -Xms{{ max (min 8192 (div .Params.NODE_MEM 4)) (min 1024 (div .Params.NODE_MEM 2)) }}m
-    -Xmx{{ max (min 8192 (div .Params.NODE_MEM 4)) (min 1024 (div .Params.NODE_MEM 2)) }}m
+    -Xms{{ max (min 8192 (div .Params.NODE_MEM_MIB 4)) (min 1024 (div .Params.NODE_MEM_MIB 2)) }}m
+    {{ end }}
+
+    {{ if .Params.NODE_MAX_HEAP_SIZE_MB }}
+    -Xmx{{ .Params.NODE_MAX_HEAP_SIZE_MB }}M
+    {{ else }}
+    -Xmx{{ max (min 8192 (div .Params.NODE_MEM_MIB 4)) (min 1024 (div .Params.NODE_MEM_MIB 2)) }}m
     {{ end }}
 
     # Young generation size is automatically calculated by cassandra-env
@@ -210,8 +214,10 @@ data:
     # The example below assumes a modern 8-core+ machine for decent
     # times. If in doubt, and if you do not particularly want to tweak, go
     # 100 MB per physical CPU core.
-    {{ if .Params.CASSANDRA_HEAP_SIZE_MB }}
-    -Xmn{{ .Params.CASSANDRA_HEAP_NEW_MB }}M
+    #
+    # TODO(mpereira): calculate this automatically based on the formula above.
+    {{ if .Params.NODE_NEW_GENERATION_HEAP_SIZE_MB }}
+    -Xmn{{ .Params.NODE_NEW_GENERATION_HEAP_SIZE_MB }}M
     {{ end }}
 
     ###################################

--- a/operator/templates/stateful-set.yaml
+++ b/operator/templates/stateful-set.yaml
@@ -99,11 +99,11 @@ spec:
                   fieldPath: metadata.uid
           resources:
             requests:
-              memory: "{{ .Params.NODE_MEM }}Mi"
-              cpu: {{ .Params.NODE_CPUS }}
+              memory: "{{ .Params.NODE_MEM_MIB }}Mi"
+              cpu: "{{ .Params.NODE_CPU_MC }}m"
             limits:
-              memory: "{{ .Params.NODE_MEM }}Mi"
-              cpu: {{ .Params.NODE_CPUS }}
+              memory: "{{ .Params.NODE_MEM_LIMIT_MIB }}Mi"
+              cpu: "{{ .Params.NODE_CPU_LIMIT_MC }}m"
           # Port names can't be longer than 15 characters.
           ports:
             - containerPort: {{ .Params.STORAGE_PORT }}
@@ -158,7 +158,7 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: {{ .Params.DISK_SIZE }}
-        {{ if .Params.STORAGE_CLASS }}
-        storageClassName: {{ .Params.STORAGE_CLASS }}
+            storage: "{{ .Params.NODE_DISK_SIZE_GIB }}Gi"
+        {{ if .Params.NODE_STORAGE_CLASS }}
+        storageClassName: {{ .Params.NODE_STORAGE_CLASS }}
         {{ end }}


### PR DESCRIPTION
- Improve names of a few settings to reflect their units.
- Rename `CLUSTER_NAME` to `OVERRIDE_CLUSTER_NAME` to make it clearer that it doesn't need to be set.
- Use the correct setting in a few places where incorrect ones were being used.
- Add some helpful comments and TODOs.
- Some layout improvements.
- Some prose improvements.