### PR TITLE
Fix boolean templating issue

### DIFF
--- a/operator/templates/service.yaml
+++ b/operator/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
       name: ssl-storage
     - port: {{ .Params.NATIVE_TRANSPORT_PORT }}
       name: native-transport
-    {{ if .Params.START_RPC }}
+    {{ if eq .Params.START_RPC "true" }}
     - port: {{ .Params.RPC_PORT }}
       name: rpc
     {{ end }}

--- a/operator/templates/stateful-set.yaml
+++ b/operator/templates/stateful-set.yaml
@@ -112,7 +112,7 @@ spec:
               name: ssl-storage
             - containerPort: {{ .Params.NATIVE_TRANSPORT_PORT }}
               name: native
-            {{ if .Params.START_RPC }}
+            {{ if eq .Params.START_RPC "true" }}
             - containerPort: {{ .Params.RPC_PORT }}
               name: rpc
             {{ end }}
@@ -159,6 +159,6 @@ spec:
         resources:
           requests:
             storage: "{{ .Params.NODE_DISK_SIZE_GIB }}Gi"
-        {{ if .Params.NODE_STORAGE_CLASS }}
+        {{ if eq .Params.NODE_STORAGE_CLASS "true" }}
         storageClassName: {{ .Params.NODE_STORAGE_CLASS }}
         {{ end }}


### PR DESCRIPTION
When we have a boolean property defined in params.yaml like this:
```
enableX:
  description: "Enable X"
  default: false
  displayName: "Enable X"
```
And when we try to use it in a template like that:
```
{{ if .Params.enableX }}
  some config
{{ end }}
```
`{{ if .Params.enableX }}` evaluates to true because `.Params.enableX` is treated as a non-empty string here and some config gets to the resulting spec disregarding the boolean value of `.Params.enableX`.
To make it work as expected we had to do this:
```
{{ if eq .Params.enableX "true" }}
  some config
{{ end }}
```