### PR TITLE
Readiness probe improvements

### DIFF
--- a/operator/operator.yaml
+++ b/operator/operator.yaml
@@ -16,7 +16,7 @@ tasks:
       - cassandra-env-sh.yaml
       - jvm-options.yaml
       - stateful-set.yaml
-      - cassandra-readiness-probe-sh.yaml
+      - node-readiness-probe-sh.yaml
 
 plans:
   deploy:

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -30,15 +30,15 @@ NODE_STORAGE_CLASS:
   description: "The storage class to be used in volumeClaimTemplates. By default, it is not required and the default storage class is used."
   required: false
 
-NODE_READINESS_PROBE_INITIAL_DELAY:
+NODE_READINESS_PROBE_INITIAL_DELAY_S:
   description: "Number of seconds after the container has started before the readiness probe is initiated."
   default: "0"
 
-NODE_READINESS_PROBE_PERIOD:
+NODE_READINESS_PROBE_PERIOD_S:
   description: "How often (in seconds) to perform the readiness probe."
   default: "5"
 
-NODE_READINESS_PROBE_TIMEOUT:
+NODE_READINESS_PROBE_TIMEOUT_S:
   description: "How long (in seconds) to wait for a readiness probe to succeed."
   default: "60"
 

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -30,6 +30,26 @@ NODE_STORAGE_CLASS:
   description: "The storage class to be used in volumeClaimTemplates. By default, it is not required and the default storage class is used."
   required: false
 
+NODE_READINESS_PROBE_INITIAL_DELAY:
+  description: "Number of seconds after the container has started before the readiness check is initiated."
+  default: "0"
+
+NODE_READINESS_PROBE_PERIOD:
+  description: "How often (in seconds) to perform the readiness check."
+  default: "5"
+
+NODE_READINESS_PROBE_TIMEOUT:
+  description: "An amount of time in seconds to wait for a readiness check to succeed."
+  default: "60"
+
+NODE_READINESS_PROBE_SUCCESS_THRESHOLD:
+  description: "Minimum consecutive successes for the probe to be considered successful after having failed."
+  default: "1"
+
+NODE_READINESS_PROBE_FAILURE_THRESHOLD:
+  description: "When a Pod starts and the check fails, Kubernetes will try failure_threshold times before giving up. Giving up means marking the pod Unready."
+  default: "3"
+
 OVERRIDE_CLUSTER_NAME:
   description: "Override the name of the Cassandra cluster set by the operator. This shouldn't be explicit set, unless you know what you're doing."
   default: ""
@@ -701,23 +721,3 @@ JVM_OPT_MAX_GC_PAUSE_MILLIS:
 JVM_OPT_G1R_SET_UPDATING_PAUSE_TIME_PERCENT:
   description: "Have the JVM do less remembered set work during STW, instead preferring concurrent GC. Reduces p99.9 latency."
   default:
-
-READINESS_PROBE_INITIAL_DELAY:
-  description: "Number of seconds after the container has started before the readiness check is initiated."
-  default: "0"
-
-READINESS_PROBE_PERIOD:
-  description: "How often (in seconds) to perform the readiness check."
-  default: "5"
-
-READINESS_PROBE_TIMEOUT:
-  description: "An amount of time in seconds to wait for a readiness check to succeed."
-  default: "60"
-
-READINESS_PROBE_SUCCESS_THRESHOLD:
-  description: "Minimum consecutive successes for the probe to be considered successful after having failed."
-  default: "1"
-
-READINESS_PROBE_FAILURE_THRESHOLD:
-  description: "When a Pod starts and the check fails, Kubernetes will try failure_threshold times before giving up. Giving up means marking the pod Unready."
-  default: "3"

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -31,15 +31,15 @@ NODE_STORAGE_CLASS:
   required: false
 
 NODE_READINESS_PROBE_INITIAL_DELAY:
-  description: "Number of seconds after the container has started before the readiness check is initiated."
+  description: "Number of seconds after the container has started before the readiness probe is initiated."
   default: "0"
 
 NODE_READINESS_PROBE_PERIOD:
-  description: "How often (in seconds) to perform the readiness check."
+  description: "How often (in seconds) to perform the readiness probe."
   default: "5"
 
 NODE_READINESS_PROBE_TIMEOUT:
-  description: "An amount of time in seconds to wait for a readiness check to succeed."
+  description: "How long (in seconds) to wait for a readiness probe to succeed."
   default: "60"
 
 NODE_READINESS_PROBE_SUCCESS_THRESHOLD:
@@ -47,7 +47,7 @@ NODE_READINESS_PROBE_SUCCESS_THRESHOLD:
   default: "1"
 
 NODE_READINESS_PROBE_FAILURE_THRESHOLD:
-  description: "When a Pod starts and the check fails, Kubernetes will try failure_threshold times before giving up. Giving up means marking the pod Unready."
+  description: "When a pod starts and the probe fails, `failure_threshold` attempts will be made before marking the pod as 'unready'."
   default: "3"
 
 OVERRIDE_CLUSTER_NAME:

--- a/operator/templates/node-readiness-probe-sh.yaml
+++ b/operator/templates/node-readiness-probe-sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cassandra-readiness-probe-sh
+  name: node-readiness-probe-sh
 data:
-  cassandra-readiness-probe.sh: |
+  node-readiness-probe.sh: |
     nodetool status -p {{ .Params.JMX_PORT }} | grep -q "UN  ${POD_IP}"

--- a/operator/templates/stateful-set.yaml
+++ b/operator/templates/stateful-set.yaml
@@ -66,7 +66,7 @@ spec:
             exec:
               command:
                   - /bin/bash
-                  - /etc/cassandra/cassandra-readiness-probe.sh
+                  - /etc/cassandra/node-readiness-probe.sh
             initialDelaySeconds: {{ .Params.NODE_READINESS_PROBE_INITIAL_DELAY }}
             periodSeconds: {{ .Params.NODE_READINESS_PROBE_PERIOD }}
             timeoutSeconds: {{ .Params.NODE_READINESS_PROBE_TIMEOUT }}
@@ -143,9 +143,9 @@ spec:
             - name: jvm-options
               mountPath: /etc/cassandra/jvm.options
               subPath: jvm.options
-            - name: cassandra-readiness-probe-sh
-              mountPath: /etc/cassandra/cassandra-readiness-probe.sh
-              subPath: cassandra-readiness-probe.sh
+            - name: node-readiness-probe-sh
+              mountPath: /etc/cassandra/node-readiness-probe.sh
+              subPath: node-readiness-probe.sh
       volumes:
         # Overwriting /etc/cassandra/ available in the Docker image.
         - name: etc-cassandra
@@ -159,9 +159,9 @@ spec:
         - name: jvm-options
           configMap:
             name: {{ .Name }}-jvm-options
-        - name: cassandra-readiness-probe-sh
+        - name: node-readiness-probe-sh
           configMap:
-            name: {{ .Name }}-cassandra-readiness-probe-sh
+            name: {{ .Name }}-node-readiness-probe-sh
   volumeClaimTemplates:
     - metadata:
         name: var-lib-cassandra

--- a/operator/templates/stateful-set.yaml
+++ b/operator/templates/stateful-set.yaml
@@ -67,9 +67,9 @@ spec:
               command:
                   - /bin/bash
                   - /etc/cassandra/node-readiness-probe.sh
-            initialDelaySeconds: {{ .Params.NODE_READINESS_PROBE_INITIAL_DELAY }}
-            periodSeconds: {{ .Params.NODE_READINESS_PROBE_PERIOD }}
-            timeoutSeconds: {{ .Params.NODE_READINESS_PROBE_TIMEOUT }}
+            initialDelaySeconds: {{ .Params.NODE_READINESS_PROBE_INITIAL_DELAY_S }}
+            periodSeconds: {{ .Params.NODE_READINESS_PROBE_PERIOD_S }}
+            timeoutSeconds: {{ .Params.NODE_READINESS_PROBE_TIMEOUT_S }}
             successThreshold: {{ .Params.NODE_READINESS_PROBE_SUCCESS_THRESHOLD }}
             failureThreshold: {{ .Params.NODE_READINESS_PROBE_FAILURE_THRESHOLD }}
           command:

--- a/operator/templates/stateful-set.yaml
+++ b/operator/templates/stateful-set.yaml
@@ -67,11 +67,11 @@ spec:
               command:
                   - /bin/bash
                   - /etc/cassandra/cassandra-readiness-probe.sh
-            initialDelaySeconds: {{ .Params.READINESS_PROBE_INITIAL_DELAY }}
-            periodSeconds: {{ .Params.READINESS_PROBE_PERIOD }}
-            timeoutSeconds: {{ .Params.READINESS_PROBE_TIMEOUT }}
-            successThreshold: {{ .Params.READINESS_PROBE_SUCCESS_THRESHOLD }}
-            failureThreshold: {{ .Params.READINESS_PROBE_FAILURE_THRESHOLD }}
+            initialDelaySeconds: {{ .Params.NODE_READINESS_PROBE_INITIAL_DELAY }}
+            periodSeconds: {{ .Params.NODE_READINESS_PROBE_PERIOD }}
+            timeoutSeconds: {{ .Params.NODE_READINESS_PROBE_TIMEOUT }}
+            successThreshold: {{ .Params.NODE_READINESS_PROBE_SUCCESS_THRESHOLD }}
+            failureThreshold: {{ .Params.NODE_READINESS_PROBE_FAILURE_THRESHOLD }}
           command:
             - cassandra
             - -f

--- a/templates/operator/operator.yaml.template
+++ b/templates/operator/operator.yaml.template
@@ -16,7 +16,7 @@ tasks:
       - cassandra-env-sh.yaml
       - jvm-options.yaml
       - stateful-set.yaml
-      - cassandra-readiness-probe-sh.yaml
+      - node-readiness-probe-sh.yaml
 
 plans:
   deploy:


### PR DESCRIPTION
- Move "readiness probe"-related params to the operator settings block.
- Prepend `NODE_` to "readiness probe"-related params to be consistent with per-container naming.
- `s/cassandra-readiness-probe/node-readiness-probe/` to be consistent with per-container naming.