### PR TITLE
upgrade cassandra to 3.11.5

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM cassandra:3.11.4
+FROM cassandra:3.11.5
 
 RUN set -eux; \
   apt-get update; \

--- a/metadata.sh
+++ b/metadata.sh
@@ -21,7 +21,7 @@ export OPERATOR_NAME="cassandra"
 # out:
 # - https://github.com/kudobuilder/kudo/pull/889
 # - https://github.com/kudobuilder/kudo/issues/163
-export OPERATOR_VERSION="0.1.0"
+export OPERATOR_VERSION="0.1.1"
 export OPERATOR_VERSION_SNAPSHOT="-SNAPSHOT"
 
 export OPERATOR_DIRECTORY="${_project_directory}/operator"
@@ -31,10 +31,10 @@ export VENDOR_DIRECTORY="${_project_directory}/shared/vendor"
 ############################### Dependencies ###################################
 ################################################################################
 
-# http://www.apache.org/dyn/closer.lua/cassandra/3.11.4
+# http://www.apache.org/dyn/closer.lua/cassandra/3.11.5
 # https://hub.docker.com/_/cassandra
 # https://github.com/docker-library/cassandra/blob/master/3.11/Dockerfile
-export CASSANDRA_VERSION="3.11.4"
+export CASSANDRA_VERSION="3.11.5"
 
 # https://github.com/kudobuilder/kudo/releases/tag/v0.8.0-pre.2
 export KUDO_VERSION="0.8.0-pre.2"

--- a/operator/operator.yaml
+++ b/operator/operator.yaml
@@ -1,9 +1,9 @@
 apiVersion: kudo.dev/v1beta1
 name: "cassandra"
-version: "0.1.0"
+version: "0.1.1"
 kudoVersion: "0.8.0-pre.2"
 kubernetesVersion: "1.15.0"
-appVersion: "3.11.4"
+appVersion: "3.11.5"
 maintainers:
   - name: Murilo Pereira
     email: murilo@murilopereira.com

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -34,7 +34,7 @@ parameters:
 
   - name: NODE_DOCKER_IMAGE
     description: "Cassandra node Docker image."
-    default: "mesosphere/cassandra:0.1.0-3.11.4-SNAPSHOT"
+    default: "viivek46/cassandra:3.11.5"
 
   - name: NODE_DOCKER_IMAGE_PULL_POLICY
     description: "Cassandra node Docker image pull policy."

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -659,6 +659,14 @@ parameters:
     description: "How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection."
     default: ""
 
+  - name: REPAIR_SESSION_MAX_TREE_DEPTH
+    description: "Limits the maximum Merkle tree depth to avoid consuming too much memory during repairs."
+    default: ""
+
+  - name: ENABLE_SASI_INDEXES
+    description: "Enables SASI index creation on this node. SASI indexes are considered experimental and are not recommended for production use."
+    default: ""
+
   ################################################################################
   ################################ JVM Options ###################################
   ################################################################################

--- a/operator/templates/cassandra-env-sh.yaml
+++ b/operator/templates/cassandra-env-sh.yaml
@@ -290,7 +290,7 @@ data:
     ## which delegates to the IAuthenticator configured in cassandra.yaml. See the sample JAAS configuration
     ## file cassandra-jaas.config
     #JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.remote.login.config=CassandraLogin"
-    #JVM_OPTS="$JVM_OPTS -Djava.security.auth.login.config=$CASSANDRA_HOME/conf/cassandra-jaas.config"
+    #JVM_OPTS="$JVM_OPTS -Djava.security.auth.login.config=$CASSANDRA_CONF/cassandra-jaas.config"
 
     ## Cassandra also ships with a helper for delegating JMX authz calls to the configured IAuthorizer,
     ## uncomment this to use it. Requires one of the two authentication options to be enabled
@@ -298,7 +298,7 @@ data:
 
     # To use mx4j, an HTML interface for JMX, add mx4j-tools.jar to the lib/
     # directory.
-    # See http://wiki.apache.org/cassandra/Operations#Monitoring_with_MX4J
+    # See http://cassandra.apache.org/doc/3.11/operating/metrics.html#jmx
     # By default mx4j listens on 0.0.0.0:8081. Uncomment the following lines
     # to control its listen address and port.
     #MX4J_ADDRESS="-Dmx4jaddress=127.0.0.1"

--- a/operator/templates/cassandra-yaml.yaml
+++ b/operator/templates/cassandra-yaml.yaml
@@ -569,7 +569,9 @@ data:
     #
     # For more details see https://issues.apache.org/jira/browse/CASSANDRA-14096.
     #
-    # repair_session_max_tree_depth: 18
+    {{ if .Params.REPAIR_SESSION_MAX_TREE_DEPTH }}
+    repair_session_max_tree_depth: {{ .Params.REPAIR_SESSION_MAX_TREE_DEPTH }}
+    {{ end }}
 
     # Total space to use for commit logs on disk.
     #
@@ -1372,4 +1374,6 @@ data:
 
     # Enables SASI index creation on this node.
     # SASI indexes are considered experimental and are not recommended for production use.
-    #enable_sasi_indexes: true
+    {{ if .Params.ENABLE_SASI_INDEXES }}
+    enable_sasi_indexes: {{ .Params.ENABLE_SASI_INDEXES }}
+    {{ end }}

--- a/operator/templates/cassandra-yaml.yaml
+++ b/operator/templates/cassandra-yaml.yaml
@@ -558,6 +558,19 @@ data:
     #    off heap objects
     memtable_allocation_type: {{ .Params.MEMTABLE_ALLOCATION_TYPE }}
 
+    # Limits the maximum Merkle tree depth to avoid consuming too much
+    # memory during repairs.
+    #
+    # The default setting of 18 generates trees of maximum size around
+    # 50 MiB / tree. If you are running out of memory during repairs consider
+    # lowering this to 15 (~6 MiB / tree) or lower, but try not to lower it
+    # too much past that or you will lose too much resolution and stream
+    # too much redundant data during repair. Cannot be set lower than 10.
+    #
+    # For more details see https://issues.apache.org/jira/browse/CASSANDRA-14096.
+    #
+    # repair_session_max_tree_depth: 18
+
     # Total space to use for commit logs on disk.
     #
     # If space gets above this value, Cassandra will flush every dirty CF
@@ -1352,3 +1365,11 @@ data:
     {{ if .Params.OTC_BACKLOG_EXPIRATION_INTERVAL_MS }}
     otc_backlog_expiration_interval_ms: {{ .Params.OTC_BACKLOG_EXPIRATION_INTERVAL_MS }}
     {{ end }}
+    
+    #########################
+    # EXPERIMENTAL FEATURES #
+    #########################
+
+    # Enables SASI index creation on this node.
+    # SASI indexes are considered experimental and are not recommended for production use.
+    #enable_sasi_indexes: true


### PR DESCRIPTION
## What changes are proposed in this PR? 
Resolves  [DCOS-58981](https://jira.mesosphere.com/browse/DCOS-58981)

## How were these changes tested?
CI tests to check functionality of cassandra-3.11.5
Upgrade from 3.11.4 to 3.11.5 is manually tested and Below are steps to check :
1. Install Cassandra 3.11.4 operator, check deploy plan status to `COMPLETE`
2. Run below upgrade command from cassandra 3.11.5 operator folder : 
```
kubectl kudo upgrade ./operator         --instance="${kudo_cassandra_instance_name}"         --namespace="${kudo_cassandra_instance_namespace}"
```
3. To check operator verions we can run  
`kubectl  get operatorversions`