### PR TITLE
Fix uninstall script.

### DIFF
--- a/scripts/uninstall_operator.sh
+++ b/scripts/uninstall_operator.sh
@@ -74,19 +74,19 @@ for parameter in operator_name \
   fi
 done
 
-${kubectl} delete instance \
+${kubectl} delete instance.kudo.dev \
            "${operator_instance_name}" \
            -n "${operator_instance_namespace}"
 
 # TODO(mpereira): add a flag to skip operatorversion deletion?
-${kubectl} delete operatorversion \
+${kubectl} delete operatorversion.kudo.dev \
            "${operator_name}-${operator_version}" \
            -n "${operator_instance_namespace}"
 
 # TODO(mpereira): add a flag to skip operator deletion?
-${kubectl} delete operator \
-        "${operator_name}" \
-        -n "${operator_instance_namespace}"
+${kubectl} delete operator.kudo.dev \
+           "${operator_name}" \
+           -n "${operator_instance_namespace}"
 
 # TODO(mpereira): add a flag to skip pvc deletion?
 declare -a PVCS

--- a/scripts/uninstall_operator.sh
+++ b/scripts/uninstall_operator.sh
@@ -92,8 +92,8 @@ ${kubectl} delete operator.kudo.dev \
 declare -a PVCS
 mapfile -t PVCS < <(
   ${kubectl} get pvc \
-          -n "${operator_instance_namespace}" \
-          -o 'jsonpath={.items[*].metadata.name}' \
+             -n "${operator_instance_namespace}" \
+             -o 'jsonpath={.items[*].metadata.name}' \
     | tr ' ' '\n'
 )
 


### PR DESCRIPTION
Making the resource names specific helps in cases where partial name matches would result in different resource types.