### PR TITLE
Update to latest release, drop the chown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Changed
 
+- Bumped Cassandra Prometheus Exporter to 2.3.3.
+  ([#56](https://github.com/mesosphere/kudo-cassandra-operator/pull/56))
+
 ### Added
 
 - TLS encryption for node-to-node and client-to-node connections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Changed
 
-- Bumped Cassandra Prometheus Exporter to 2.3.3.
+- Bumped Cassandra Prometheus Exporter to 2.3.4.
   ([#56](https://github.com/mesosphere/kudo-cassandra-operator/pull/56))
 
 ### Added

--- a/images/Dockerfile.prometheus-exporter
+++ b/images/Dockerfile.prometheus-exporter
@@ -1,3 +1,1 @@
-FROM criteord/cassandra_exporter:2.2.1
-
-RUN chown 999:999 /opt/cassandra_exporter/cassandra_exporter.jar
+FROM criteord/cassandra_exporter:2.3.3

--- a/images/Dockerfile.prometheus-exporter
+++ b/images/Dockerfile.prometheus-exporter
@@ -1,1 +1,1 @@
-FROM criteord/cassandra_exporter:2.3.3
+FROM criteord/cassandra_exporter:2.3.4

--- a/metadata.sh
+++ b/metadata.sh
@@ -43,7 +43,7 @@ export KUDO_VERSION="0.10.1"
 export KUBERNETES_VERSION="1.15.0"
 
 export CASSANDRA_EXPORTER_DOCKER_IMAGE="criteord/cassandra_exporter"
-export CASSANDRA_EXPORTER_VERSION="2.2.1"
+export CASSANDRA_EXPORTER_VERSION="2.3.3"
 
 ################################################################################
 ############################## Docker images ###################################

--- a/metadata.sh
+++ b/metadata.sh
@@ -43,7 +43,7 @@ export KUDO_VERSION="0.10.1"
 export KUBERNETES_VERSION="1.15.0"
 
 export CASSANDRA_EXPORTER_DOCKER_IMAGE="criteord/cassandra_exporter"
-export CASSANDRA_EXPORTER_VERSION="2.3.3"
+export CASSANDRA_EXPORTER_VERSION="2.3.4"
 
 ################################################################################
 ############################## Docker images ###################################

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -113,7 +113,7 @@ parameters:
 
   - name: PROMETHEUS_EXPORTER_DOCKER_IMAGE
     description: "Prometheus exporter Docker image."
-    default: "mesosphere/cassandra-prometheus-exporter:2.2.1-0.1.2-SNAPSHOT"
+    default: "mesosphere/cassandra-prometheus-exporter:2.3.3-0.1.2-SNAPSHOT"
 
   - name: PROMETHEUS_EXPORTER_DOCKER_IMAGE_PULL_POLICY
     description: "Prometheus exporter Docker image pull policy."

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -113,7 +113,7 @@ parameters:
 
   - name: PROMETHEUS_EXPORTER_DOCKER_IMAGE
     description: "Prometheus exporter Docker image."
-    default: "mesosphere/cassandra-prometheus-exporter:2.3.3-0.1.2-SNAPSHOT"
+    default: "mesosphere/cassandra-prometheus-exporter:2.3.4-0.1.2-SNAPSHOT"
 
   - name: PROMETHEUS_EXPORTER_DOCKER_IMAGE_PULL_POLICY
     description: "Prometheus exporter Docker image pull policy."

--- a/operator/templates/cassandra-exporter-config-yml.yaml
+++ b/operator/templates/cassandra-exporter-config-yml.yaml
@@ -53,7 +53,7 @@ data:
        # Don't scrape metrics from Criteo
        - com:criteo:nosql:cassandra:exporter:.*
 
-    maxScrapeFrequencyInSec:
+    maxScrapFrequencyInSec:
       50:
         - .*
 

--- a/operator/templates/cassandra-exporter-config-yml.yaml
+++ b/operator/templates/cassandra-exporter-config-yml.yaml
@@ -53,7 +53,7 @@ data:
        # Don't scrape metrics from Criteo
        - com:criteo:nosql:cassandra:exporter:.*
 
-    maxScrapFrequencyInSec:
+    maxScrapeFrequencyInSec:
       50:
         - .*
 

--- a/templates/images/Dockerfile.prometheus-exporter.template
+++ b/templates/images/Dockerfile.prometheus-exporter.template
@@ -1,3 +1,1 @@
 FROM ${PROMETHEUS_EXPORTER_DOCKER_IMAGE_FROM}
-
-RUN chown 999:999 /opt/cassandra_exporter/cassandra_exporter.jar


### PR DESCRIPTION
The permissions are now [fixed](https://github.com/criteo/cassandra_exporter/pull/68) in upstream repo, so we can drop [the chown](https://github.com/mesosphere/kudo-cassandra-operator/pull/4#pullrequestreview-353615114):
```
porridge@beczulka:~$ docker run criteord/cassandra_exporter:2.3.2 ls -l /opt/cassandra_exporter
Unable to find image 'criteord/cassandra_exporter:2.3.2' locally
2.3.2: Pulling from criteord/cassandra_exporter
bc51dd8edc1b: Pull complete 
d1d06863bb82: Pull complete 
adf4d10a782b: Pull complete 
7db4424ff270: Pull complete 
e008a301333c: Pull complete 
10121b885a52: Pull complete 
0d34188e8091: Pull complete 
fc3c7604e1c5: Pull complete 
019737f36353: Pull complete 
a26e5d6f647b: Pull complete 
3b6b59aecfbd: Pull complete 
Digest: sha256:9fe7cfef9b03ca294c80e5da098add4698c4103bbddf382dd93d2e01a073d6e3
Status: Downloaded newer image for criteord/cassandra_exporter:2.3.2
total 4760
-rw-rw-r-- 1 root root 4871483 Feb 10 13:31 cassandra_exporter.jar
porridge@beczulka:~$ 
```

<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes.

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes.

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
