### PR TITLE
Temporarily remove cassandra APT repo

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,6 +1,7 @@
 FROM cassandra:3.11.5
 
 RUN set -eux; \
+  rm /etc/apt/sources.list.d/cassandra.list; \
   apt-get update; \
   apt-get install -y --no-install-recommends libcap2-bin; \
   # Setting this capability will cause running the Java binary to not be


### PR DESCRIPTION
It's broken due to [ASF Infra changes](https://www.mail-archive.com/user@cassandra.apache.org/msg60484.html), preventing APT from working, and not really needed, since cassandra is already there in the base image.


```
Step 2/3 : RUN set -eux;   apt-get update;   apt-get install -y --no-install-recommends libcap2-bin;   setcap cap_sys_resource,cap_ipc_lock+eip $(readlink -f $(which java))
 ---> Running in b036c1c68fb7
+ apt-get update
Ign:1 http://deb.debian.org/debian stretch InRelease
Get:2 http://security.debian.org/debian-security stretch/updates InRelease [94.3 kB]
Get:3 http://deb.debian.org/debian stretch-updates InRelease [91.0 kB]
Get:4 http://deb.debian.org/debian stretch Release [118 kB]
Get:5 http://deb.debian.org/debian stretch Release.gpg [2410 B]
Get:6 http://security.debian.org/debian-security stretch/updates/main amd64 Packages [517 kB]
Get:8 http://deb.debian.org/debian stretch-updates/main amd64 Packages [27.9 kB]
Get:9 http://deb.debian.org/debian stretch/main amd64 Packages [7083 kB]
Reading package lists...
E: The method driver /usr/lib/apt/methods/https could not be found.
```

<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes.

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes.

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
