### PR TITLE
Make sure that the "compiled" files match their templates.

### DIFF
--- a/images/Dockerfile.integration-tests
+++ b/images/Dockerfile.integration-tests
@@ -1,0 +1,6 @@
+FROM golang:1.13.1-stretch
+
+# For envsubst:
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gettext-base && \
+    rm -rf /var/lib/apt/lists/*

--- a/images/build.sh
+++ b/images/build.sh
@@ -11,6 +11,7 @@ source "${project_directory}/metadata.sh"
 
 readonly cassandra_docker_image="${CASSANDRA_DOCKER_IMAGE:-}"
 readonly prometheus_exporter_docker_image="${PROMETHEUS_EXPORTER_DOCKER_IMAGE:-}"
+readonly integration_tests_docker_image="${INTEGRATION_TESTS_DOCKER_IMAGE:-}"
 
 if [[ -z ${cassandra_docker_image} ]]; then
   echo "Missing CASSANDRA_DOCKER_IMAGE" >&2
@@ -19,6 +20,11 @@ fi
 
 if [[ -z ${prometheus_exporter_docker_image} ]]; then
   echo "Missing PROMETHEUS_EXPORTER_DOCKER_IMAGE" >&2
+  exit 1
+fi
+
+if [[ -z ${integration_tests_docker_image} ]]; then
+  echo "Missing INTEGRATION_TESTS_DOCKER_IMAGE" >&2
   exit 1
 fi
 
@@ -32,7 +38,13 @@ docker image build \
        -f "${project_directory}/images/Dockerfile.prometheus-exporter" \
        "${project_directory}/images"
 
+docker image build \
+       -t "${integration_tests_docker_image}" \
+       -f "${project_directory}/images/Dockerfile.integration-tests" \
+       "${project_directory}/images"
+
 if [[ "${1:-}" == "push" ]]; then
   docker push "${cassandra_docker_image}"
   docker push "${prometheus_exporter_docker_image}"
+  docker push "${integration_tests_docker_image}"
 fi

--- a/metadata.sh
+++ b/metadata.sh
@@ -65,7 +65,11 @@ export PROMETHEUS_EXPORTER_DOCKER_IMAGE="${PROMETHEUS_EXPORTER_DOCKER_IMAGE_NAME
 ################################# Testing ######################################
 ################################################################################
 
-export INTEGRATION_TESTS_DOCKER_IMAGE="golang:1.13.1-stretch"
+export INTEGRATION_TESTS_DOCKER_IMAGE_FROM="golang:1.13.1-stretch"
+export INTEGRATION_TESTS_DOCKER_IMAGE_NAMESPACE="mesosphere"
+export INTEGRATION_TESTS_DOCKER_IMAGE_NAME="kudo-cassandra-tests"
+export INTEGRATION_TESTS_DOCKER_IMAGE_TAG="latest"
+export INTEGRATION_TESTS_DOCKER_IMAGE="${INTEGRATION_TESTS_DOCKER_IMAGE_NAMESPACE}/${INTEGRATION_TESTS_DOCKER_IMAGE_NAME}:${INTEGRATION_TESTS_DOCKER_IMAGE_TAG}"
 
 ################################################################################
 ############################# Data Services ####################################

--- a/templates/images/Dockerfile.integration-tests.template
+++ b/templates/images/Dockerfile.integration-tests.template
@@ -1,0 +1,6 @@
+FROM ${INTEGRATION_TESTS_DOCKER_IMAGE_FROM}
+
+# For envsubst:
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gettext-base && \
+    rm -rf /var/lib/apt/lists/*

--- a/templates/images/Dockerfile.template
+++ b/templates/images/Dockerfile.template
@@ -1,6 +1,7 @@
 FROM ${CASSANDRA_DOCKER_IMAGE_FROM}
 
 RUN set -eux; \
+  rm /etc/apt/sources.list.d/cassandra.list; \
   apt-get update; \
   apt-get install -y --no-install-recommends libcap2-bin; \
   # Setting this capability will cause running the Java binary to not be

--- a/templates/operator/operator.yaml.template
+++ b/templates/operator/operator.yaml.template
@@ -25,7 +25,6 @@ tasks:
         - generate-tls-artifacts-sh.yaml
         - generate-cqlshrc-sh.yaml
         - external-service.yaml
-
 plans:
   deploy:
     strategy: serial

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,6 +32,9 @@ fi
 # Give more priority to vendored executables.
 export PATH=${VENDOR_DIRECTORY}:${PATH}
 
+cd "${project_directory}"
+./tools/compile_templates.sh --check-only
+
 cd "${project_directory}/tests"
 
 go mod edit -require "github.com/kudobuilder/kudo@${DS_KUDO_VERSION}"


### PR DESCRIPTION
To keep CI green:
- switch from using `golang:1.13.1-stretch` test image to a customized one with `gettext-base` installed so we can actually run `envsubst`
- update templates which went out of sync

<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes.

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes.

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->