### PR TITLE
add podManagementPolicy param to enable parallel deploy

### DIFF
--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -864,3 +864,7 @@ parameters:
   - name: CUSTOM_JVM_OPTIONS_BASE64
     description: "Base64-encoded JVM options appended to jvm.options."
     default: ""
+
+  - name: POD_MANAGEMENT_POLICY
+    description: "podManagementPolicy of the Cassandra Statefulset"
+    default: "OrderedReady"

--- a/operator/templates/stateful-set.yaml
+++ b/operator/templates/stateful-set.yaml
@@ -29,6 +29,7 @@ spec:
   {{ else }}
   replicas: {{ $.Params.NODE_COUNT }}
   {{ end }}
+  podManagementPolicy: {{ $.Params.POD_MANAGEMENT_POLICY }}
   template:
     metadata:
       labels:

--- a/templates/operator/params.yaml.template
+++ b/templates/operator/params.yaml.template
@@ -864,3 +864,7 @@ parameters:
   - name: CUSTOM_JVM_OPTIONS_BASE64
     description: "Base64-encoded JVM options appended to jvm.options."
     default: ""
+
+  - name: POD_MANAGEMENT_POLICY
+    description: "podManagementPolicy of the Cassandra Statefulset"
+    default: "OrderedReady"

--- a/templates/operator/templates/stateful-set.yaml.template
+++ b/templates/operator/templates/stateful-set.yaml.template
@@ -29,6 +29,7 @@ spec:
   {{ else }}
   replicas: {{ $.Params.NODE_COUNT }}
   {{ end }}
+  podManagementPolicy: {{ $.Params.POD_MANAGEMENT_POLICY }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Zain Malik <zmalikshxil@gmail.com>

Adds the podManagementPolicy parameter so we can deploy in parallel Cassandra pods.