### PR TITLE
Configure liveness probes for pods

### DIFF
--- a/operator/operator.yaml
+++ b/operator/operator.yaml
@@ -21,7 +21,7 @@ tasks:
         - stateful-set.yaml
         - cassandra-exporter-config-yml.yaml
         - service-monitor.yaml
-        - node-readiness-probe-sh.yaml
+        - node-scripts.yaml
         - generate-tls-artifacts-sh.yaml
         - generate-cqlshrc-sh.yaml
         - pdb.yaml

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -53,11 +53,31 @@ parameters:
     default: "60"
 
   - name: NODE_READINESS_PROBE_SUCCESS_THRESHOLD
-    description: "Minimum consecutive successes for the probe to be considered successful after having failed."
+    description: "Minimum consecutive successes for the readiness probe to be considered successful after having failed."
     default: "1"
 
   - name: NODE_READINESS_PROBE_FAILURE_THRESHOLD
-    description: "When a pod starts and the probe fails, `failure_threshold` attempts will be made before marking the pod as 'unready'."
+    description: "When a pod starts and the readiness probe fails, `failure_threshold` attempts will be made before marking the pod as 'unready'."
+    default: "3"
+
+  - name: NODE_LIVENESS_PROBE_INITIAL_DELAY_S
+    description: "Number of seconds after the container has started before the liveness probe is initiated."
+    default: "15"
+
+  - name: NODE_LIVENESS_PROBE_PERIOD_S
+    description: "How often (in seconds) to perform the liveness probe."
+    default: "20"
+
+  - name: NODE_LIVENESS_PROBE_TIMEOUT_S
+    description: "How long (in seconds) to wait for a liveness probe to succeed."
+    default: "60"
+
+  - name: NODE_LIVENESS_PROBE_SUCCESS_THRESHOLD
+    description: "Minimum consecutive successes for the liveness probe to be considered successful after having failed."
+    default: "1"
+
+  - name: NODE_LIVENESS_PROBE_FAILURE_THRESHOLD
+    description: "When a pod starts and the liveness probe fails, `failure_threshold` attempts will be made before restarting the pod."
     default: "3"
 
   - name: OVERRIDE_CLUSTER_NAME

--- a/operator/templates/node-scripts.yaml
+++ b/operator/templates/node-scripts.yaml
@@ -6,6 +6,8 @@ metadata:
 data:
   node-readiness-probe.sh: |
     nodetool status -p {{ .Params.JMX_PORT }} | grep -q "UN  ${POD_IP}"
+  node-liveness-probe.sh: |
+    nodetool info
   generate-rackdc-properties.sh: |
     # Generate the rackdc-properties
     RACK=`kubectl get node -L$RACKLABEL | grep ${NODE_NAME} | awk '{print $6}'`

--- a/operator/templates/node-scripts.yaml
+++ b/operator/templates/node-scripts.yaml
@@ -1,11 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Name }}-node-readiness-probe-sh
+  name: {{ .Name }}-node-scripts
   namespace: {{ .Namespace }}
 data:
   node-readiness-probe.sh: |
     nodetool status -p {{ .Params.JMX_PORT }} | grep -q "UN  ${POD_IP}"
+  node-liveness-probe.sh: |
+    nodetool info
   generate-rackdc-properties.sh: |
     # Generate the rackdc-properties
     RACK=`kubectl get node -L$RACKLABEL | grep ${NODE_NAME} | awk '{print $6}'`

--- a/operator/templates/node-scripts.yaml
+++ b/operator/templates/node-scripts.yaml
@@ -6,8 +6,6 @@ metadata:
 data:
   node-readiness-probe.sh: |
     nodetool status -p {{ .Params.JMX_PORT }} | grep -q "UN  ${POD_IP}"
-  node-liveness-probe.sh: |
-    nodetool info
   generate-rackdc-properties.sh: |
     # Generate the rackdc-properties
     RACK=`kubectl get node -L$RACKLABEL | grep ${NODE_NAME} | awk '{print $6}'`

--- a/operator/templates/stateful-set.yaml
+++ b/operator/templates/stateful-set.yaml
@@ -134,8 +134,10 @@ spec:
             successThreshold: {{ $.Params.NODE_READINESS_PROBE_SUCCESS_THRESHOLD }}
             failureThreshold: {{ $.Params.NODE_READINESS_PROBE_FAILURE_THRESHOLD }}
           livenessProbe:
-            tcpSocket:
-              port: {{ $.Params.JMX_PORT }}
+            exec:
+              command:
+                - /bin/bash
+                - /etc/cassandra/node-liveness-probe.sh
             initialDelaySeconds: {{ $.Params.NODE_LIVENESS_PROBE_INITIAL_DELAY_S }}
             periodSeconds: {{ $.Params.NODE_LIVENESS_PROBE_PERIOD_S }}
             timeoutSeconds: {{ $.Params.NODE_LIVENESS_PROBE_TIMEOUT_S }}
@@ -223,6 +225,9 @@ spec:
             - name: node-scripts
               mountPath: /etc/cassandra/node-readiness-probe.sh
               subPath: node-readiness-probe.sh
+            - name: node-scripts
+              mountPath: /etc/cassandra/node-liveness-probe.sh
+              subPath: node-liveness-probe.sh
             - name: dot-cassandra
               mountPath: /home/cassandra/.cassandra/
             - name: generate-cqlshrc-sh

--- a/operator/templates/stateful-set.yaml
+++ b/operator/templates/stateful-set.yaml
@@ -134,10 +134,8 @@ spec:
             successThreshold: {{ $.Params.NODE_READINESS_PROBE_SUCCESS_THRESHOLD }}
             failureThreshold: {{ $.Params.NODE_READINESS_PROBE_FAILURE_THRESHOLD }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/bash
-                - /etc/cassandra/node-liveness-probe.sh
+            tcpSocket:
+              port: {{ $.Params.JMX_PORT }}
             initialDelaySeconds: {{ $.Params.NODE_LIVENESS_PROBE_INITIAL_DELAY_S }}
             periodSeconds: {{ $.Params.NODE_LIVENESS_PROBE_PERIOD_S }}
             timeoutSeconds: {{ $.Params.NODE_LIVENESS_PROBE_TIMEOUT_S }}
@@ -225,9 +223,6 @@ spec:
             - name: node-scripts
               mountPath: /etc/cassandra/node-readiness-probe.sh
               subPath: node-readiness-probe.sh
-            - name: node-scripts
-              mountPath: /etc/cassandra/node-liveness-probe.sh
-              subPath: node-liveness-probe.sh
             - name: dot-cassandra
               mountPath: /home/cassandra/.cassandra/
             - name: generate-cqlshrc-sh

--- a/operator/templates/stateful-set.yaml
+++ b/operator/templates/stateful-set.yaml
@@ -133,6 +133,16 @@ spec:
             timeoutSeconds: {{ $.Params.NODE_READINESS_PROBE_TIMEOUT_S }}
             successThreshold: {{ $.Params.NODE_READINESS_PROBE_SUCCESS_THRESHOLD }}
             failureThreshold: {{ $.Params.NODE_READINESS_PROBE_FAILURE_THRESHOLD }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - /etc/cassandra/node-liveness-probe.sh
+            initialDelaySeconds: {{ $.Params.NODE_LIVENESS_PROBE_INITIAL_DELAY_S }}
+            periodSeconds: {{ $.Params.NODE_LIVENESS_PROBE_PERIOD_S }}
+            timeoutSeconds: {{ $.Params.NODE_LIVENESS_PROBE_TIMEOUT_S }}
+            successThreshold: {{ $.Params.NODE_LIVENESS_PROBE_SUCCESS_THRESHOLD }}
+            failureThreshold: {{ $.Params.NODE_LIVENESS_PROBE_FAILURE_THRESHOLD }}
           command:
             - bash
             - -c
@@ -212,9 +222,12 @@ spec:
             - name: jvm-options
               mountPath: /etc/cassandra/jvm.options
               subPath: jvm.options
-            - name: node-readiness-probe-sh
+            - name: node-scripts
               mountPath: /etc/cassandra/node-readiness-probe.sh
               subPath: node-readiness-probe.sh
+            - name: node-scripts
+              mountPath: /etc/cassandra/node-liveness-probe.sh
+              subPath: node-liveness-probe.sh
             - name: dot-cassandra
               mountPath: /home/cassandra/.cassandra/
             - name: generate-cqlshrc-sh
@@ -295,7 +308,7 @@ spec:
           volumeMounts:
             - name: etc-cassandra
               mountPath: /etc/cassandra/
-            - name: node-readiness-probe-sh
+            - name: node-scripts
               mountPath: /etc/cassandra/generate-rackdc-properties.sh
               subPath: generate-rackdc-properties.sh
           resources:
@@ -319,9 +332,9 @@ spec:
         - name: jvm-options
           configMap:
             name: {{ $.Name }}-jvm-options
-        - name: node-readiness-probe-sh
+        - name: node-scripts
           configMap:
-            name: {{ $.Name }}-node-readiness-probe-sh
+            name: {{ $.Name }}-node-scripts
             defaultMode: 0755
         - name: dot-cassandra
           emptyDir: {}

--- a/templates/operator/operator.yaml.template
+++ b/templates/operator/operator.yaml.template
@@ -21,7 +21,7 @@ tasks:
         - stateful-set.yaml
         - cassandra-exporter-config-yml.yaml
         - service-monitor.yaml
-        - node-readiness-probe-sh.yaml
+        - node-scripts.yaml
         - generate-tls-artifacts-sh.yaml
         - generate-cqlshrc-sh.yaml
         - pdb.yaml

--- a/templates/operator/params.yaml.template
+++ b/templates/operator/params.yaml.template
@@ -53,11 +53,31 @@ parameters:
     default: "60"
 
   - name: NODE_READINESS_PROBE_SUCCESS_THRESHOLD
-    description: "Minimum consecutive successes for the probe to be considered successful after having failed."
+    description: "Minimum consecutive successes for the readiness probe to be considered successful after having failed."
     default: "1"
 
   - name: NODE_READINESS_PROBE_FAILURE_THRESHOLD
-    description: "When a pod starts and the probe fails, `failure_threshold` attempts will be made before marking the pod as 'unready'."
+    description: "When a pod starts and the readiness probe fails, `failure_threshold` attempts will be made before marking the pod as 'unready'."
+    default: "3"
+
+  - name: NODE_LIVENESS_PROBE_INITIAL_DELAY_S
+    description: "Number of seconds after the container has started before the liveness probe is initiated."
+    default: "15"
+
+  - name: NODE_LIVENESS_PROBE_PERIOD_S
+    description: "How often (in seconds) to perform the liveness probe."
+    default: "20"
+
+  - name: NODE_LIVENESS_PROBE_TIMEOUT_S
+    description: "How long (in seconds) to wait for a liveness probe to succeed."
+    default: "60"
+
+  - name: NODE_LIVENESS_PROBE_SUCCESS_THRESHOLD
+    description: "Minimum consecutive successes for the liveness probe to be considered successful after having failed."
+    default: "1"
+
+  - name: NODE_LIVENESS_PROBE_FAILURE_THRESHOLD
+    description: "When a pod starts and the liveness probe fails, `failure_threshold` attempts will be made before restarting the pod."
     default: "3"
 
   - name: OVERRIDE_CLUSTER_NAME

--- a/templates/operator/templates/stateful-set.yaml.template
+++ b/templates/operator/templates/stateful-set.yaml.template
@@ -134,8 +134,10 @@ spec:
             successThreshold: {{ $.Params.NODE_READINESS_PROBE_SUCCESS_THRESHOLD }}
             failureThreshold: {{ $.Params.NODE_READINESS_PROBE_FAILURE_THRESHOLD }}
           livenessProbe:
-            tcpSocket:
-              port: {{ $.Params.JMX_PORT }}
+            exec:
+              command:
+                - /bin/bash
+                - /etc/cassandra/node-liveness-probe.sh
             initialDelaySeconds: {{ $.Params.NODE_LIVENESS_PROBE_INITIAL_DELAY_S }}
             periodSeconds: {{ $.Params.NODE_LIVENESS_PROBE_PERIOD_S }}
             timeoutSeconds: {{ $.Params.NODE_LIVENESS_PROBE_TIMEOUT_S }}
@@ -223,6 +225,9 @@ spec:
             - name: node-scripts
               mountPath: /etc/cassandra/node-readiness-probe.sh
               subPath: node-readiness-probe.sh
+            - name: node-scripts
+              mountPath: /etc/cassandra/node-liveness-probe.sh
+              subPath: node-liveness-probe.sh
             - name: dot-cassandra
               mountPath: /home/cassandra/.cassandra/
             - name: generate-cqlshrc-sh

--- a/templates/operator/templates/stateful-set.yaml.template
+++ b/templates/operator/templates/stateful-set.yaml.template
@@ -134,10 +134,8 @@ spec:
             successThreshold: {{ $.Params.NODE_READINESS_PROBE_SUCCESS_THRESHOLD }}
             failureThreshold: {{ $.Params.NODE_READINESS_PROBE_FAILURE_THRESHOLD }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/bash
-                - /etc/cassandra/node-liveness-probe.sh
+            tcpSocket:
+              port: {{ $.Params.JMX_PORT }}
             initialDelaySeconds: {{ $.Params.NODE_LIVENESS_PROBE_INITIAL_DELAY_S }}
             periodSeconds: {{ $.Params.NODE_LIVENESS_PROBE_PERIOD_S }}
             timeoutSeconds: {{ $.Params.NODE_LIVENESS_PROBE_TIMEOUT_S }}
@@ -225,9 +223,6 @@ spec:
             - name: node-scripts
               mountPath: /etc/cassandra/node-readiness-probe.sh
               subPath: node-readiness-probe.sh
-            - name: node-scripts
-              mountPath: /etc/cassandra/node-liveness-probe.sh
-              subPath: node-liveness-probe.sh
             - name: dot-cassandra
               mountPath: /home/cassandra/.cassandra/
             - name: generate-cqlshrc-sh

--- a/templates/operator/templates/stateful-set.yaml.template
+++ b/templates/operator/templates/stateful-set.yaml.template
@@ -133,6 +133,16 @@ spec:
             timeoutSeconds: {{ $.Params.NODE_READINESS_PROBE_TIMEOUT_S }}
             successThreshold: {{ $.Params.NODE_READINESS_PROBE_SUCCESS_THRESHOLD }}
             failureThreshold: {{ $.Params.NODE_READINESS_PROBE_FAILURE_THRESHOLD }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - /etc/cassandra/node-liveness-probe.sh
+            initialDelaySeconds: {{ $.Params.NODE_LIVENESS_PROBE_INITIAL_DELAY_S }}
+            periodSeconds: {{ $.Params.NODE_LIVENESS_PROBE_PERIOD_S }}
+            timeoutSeconds: {{ $.Params.NODE_LIVENESS_PROBE_TIMEOUT_S }}
+            successThreshold: {{ $.Params.NODE_LIVENESS_PROBE_SUCCESS_THRESHOLD }}
+            failureThreshold: {{ $.Params.NODE_LIVENESS_PROBE_FAILURE_THRESHOLD }}
           command:
             - bash
             - -c
@@ -212,9 +222,12 @@ spec:
             - name: jvm-options
               mountPath: /etc/cassandra/jvm.options
               subPath: jvm.options
-            - name: node-readiness-probe-sh
+            - name: node-scripts
               mountPath: /etc/cassandra/node-readiness-probe.sh
               subPath: node-readiness-probe.sh
+            - name: node-scripts
+              mountPath: /etc/cassandra/node-liveness-probe.sh
+              subPath: node-liveness-probe.sh
             - name: dot-cassandra
               mountPath: /home/cassandra/.cassandra/
             - name: generate-cqlshrc-sh
@@ -295,7 +308,7 @@ spec:
           volumeMounts:
             - name: etc-cassandra
               mountPath: /etc/cassandra/
-            - name: node-readiness-probe-sh
+            - name: node-scripts
               mountPath: /etc/cassandra/generate-rackdc-properties.sh
               subPath: generate-rackdc-properties.sh
           resources:
@@ -319,9 +332,9 @@ spec:
         - name: jvm-options
           configMap:
             name: {{ $.Name }}-jvm-options
-        - name: node-readiness-probe-sh
+        - name: node-scripts
           configMap:
-            name: {{ $.Name }}-node-readiness-probe-sh
+            name: {{ $.Name }}-node-scripts
             defaultMode: 0755
         - name: dot-cassandra
           emptyDir: {}


### PR DESCRIPTION
Liveness probes check that the Cassandra node running in the pod is responsive by calling 'nodetool info'. It does not consider the node's status provided by 'nodetool status' for liveness. As such it's only concerned by the liveness of the pods application.

<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes.

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes.

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
