### PR TITLE
Improvements to docker image.

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,11 +1,14 @@
 FROM golang:1.14
 
 RUN apt-get update && apt-get install -y curl wget gnupg2
-RUN wget https://dl.yarnpkg.com/debian/pubkey.gpg && apt-key add pubkey.gpg && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN wget https://dl.yarnpkg.com/debian/pubkey.gpg && \
+    apt-key add pubkey.gpg && \
+    rm pubkey.gpg && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN curl -sL https://deb.nodesource.com/setup_10.x |  bash -
 RUN apt-get update
-RUN apt-get install -y gettext-base git python3 python3-pip shellcheck yarn build-essential openssl libssl-dev nodejs
-RUN pip3 install pyyaml pytablewriter
+RUN apt-get install -y gettext-base git python3 python3-pip python3-yaml shellcheck yarn build-essential openssl libssl-dev nodejs
+RUN pip3 install pytablewriter
 RUN npm install --global prettier
 
 RUN go get golang.org/x/tools/cmd/goimports

--- a/tools/docker.sh
+++ b/tools/docker.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
 
-TOOL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
 
 if [[ $# -eq 0 ]] ; then
-    echo 'script requires the command to run in dockered linux env'
-    echo 'example:  ./tools/docker.sh ./tools/generate_parameters_markdown.py '
+    echo 'script requires the command to run in dockered linux env' >&2
+    echo 'example:  ./tools/docker.sh ./tools/generate_parameters_markdown.py ' >&2
     exit 0
 fi
 
-cd "$TOOL_DIR" || exit
-docker build . -t cass-tools
+docker build "${REPO_ROOT}/tools" -t kudo-cassandra-tools
 
-cd "$TOOL_DIR/.." || exit
-docker run  -v "$PWD:/opt/kudo-cassandra-operator" cass-tools "$1"
+docker run -v "${REPO_ROOT}:/opt/kudo-cassandra-operator" kudo-cassandra-tools "$@"


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes. This script is currently linux only. To run on another platform
   run the docker.sh script; example: ./tools/docker.sh ./tools/compile_templates.sh

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes. ./tools/docker.sh ./tools/generate_parameters_markdown.py
   This script is currently linux only. To run on another platform run the docker.sh script;
   example: ./tools/docker.sh ./tools/generate_parameters_markdown.py

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

tools/Dockerfile:
- cleanup pubkey.gpg and break long command
- install pyyaml from a deb rather than pip, since it's available and
  likely to be more stable

tools/docker.sh:
- use errexit to catch docker build failures rather than silently use a
  stale image
- echo errors to stderr
- use a $REPO_ROOT variable rather than TOOL_DIR and drop the "cd"s to
  decrease congnitive burden