### PR TITLE
Use a password file when authenticating the repair job

### DIFF
--- a/operator/templates/repair-job.yaml
+++ b/operator/templates/repair-job.yaml
@@ -1,6 +1,6 @@
 {{ $auth_params := "" }}
-{{ if $.Params.AUTHENTICATION_SECRET_NAME }}
-{{ $auth_params = "-u ${SECRET_USERNAME} -pw ${SECRET_PASSWORD}" }}
+{{ if .Params.AUTHENTICATION_SECRET_NAME }}
+{{ $auth_params = "-u \\\\$(cat /etc/cassandra/authentication/username) -pwf <(paste -d ' ' /etc/cassandra/authentication/username /etc/cassandra/authentication/password)" }}
 {{ end }}
 ---
 apiVersion: batch/v1
@@ -18,19 +18,6 @@ spec:
         - name: repair-job
           image: bitnami/kubectl:{{ $.Params.KUBECTL_VERSION }}
           command: ["/bin/bash"]
-          args: [ "-c", "kubectl exec {{ $.Params.REPAIR_POD }} -- nodetool {{ $auth_params }} repair"]
-          {{ if $.Params.AUTHENTICATION_SECRET_NAME }}
-          env:
-            - name: SECRET_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Params.AUTHENTICATION_SECRET_NAME }}
-                  key: username
-            - name: SECRET_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Params.AUTHENTICATION_SECRET_NAME }}
-                  key: password
-          {{ end }}
+          args: [ "-c", "kubectl exec {{ $.Params.REPAIR_POD }} -- /bin/bash -c \"nodetool {{ $auth_params }} repair\""]
       restartPolicy: Never
       serviceAccountName: {{ .Name }}-node-repairer


### PR DESCRIPTION
This avoid leaking the password through the process name. This is an addition to https://github.com/mesosphere/kudo-cassandra-operator/pull/88. The insecure usage of `nodetool repair` mentioned there has been fixed.

<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes. This script is currently linux only. To run on another platform
   run the docker.sh script; example: ./tools/docker.sh ./tools/compile_templates.sh

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes. ./tools/docker.sh ./tools/generate_parameters_markdown.py
   This script is currently linux only. To run on another platform run the docker.sh script;
   example: ./tools/docker.sh ./tools/generate_parameters_markdown.py

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
