### PR TITLE
Make sure that suffix is passed when necessary.

### DIFF
--- a/images/build.sh
+++ b/images/build.sh
@@ -11,7 +11,9 @@ source "${project_directory}/metadata.sh"
 
 if [[ -n ${IMAGE_DISAMBIGUATION_SUFFIX:-} ]]; then
   # Refresh templated files to pick up the suffix, if explicitly set.
-  "${project_directory}/tools/docker.sh" "${project_directory}/tools/compile_templates.sh"
+  "${project_directory}/tools/docker.sh" \
+    env "IMAGE_DISAMBIGUATION_SUFFIX=${IMAGE_DISAMBIGUATION_SUFFIX}" \
+    "${project_directory}/tools/compile_templates.sh"
 fi
 
 readonly cassandra_docker_image="${CASSANDRA_DOCKER_IMAGE:-}"


### PR DESCRIPTION
Pass the variable explicitly.

Wrapping with docker.sh was added for convenience of dispatch in #109 but
effectively made this line a no-op.


<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes. This script is currently linux only. To run on another platform
   run the docker.sh script; example: ./tools/docker.sh ./tools/compile_templates.sh

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes. ./tools/docker.sh ./tools/generate_parameters_markdown.py
   This script is currently linux only. To run on another platform run the docker.sh script;
   example: ./tools/docker.sh ./tools/generate_parameters_markdown.py

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->