### PR TITLE
Remove the VERBOSE variable in compile_templates.sh

### DIFF
--- a/tools/compile_templates.sh
+++ b/tools/compile_templates.sh
@@ -13,7 +13,6 @@ fi
 source "${project_directory}/metadata.sh"
 
 readonly DEBUG="${DEBUG:=false}"
-readonly VERBOSE="${VERBOSE:=false}"
 CHECK_ONLY=false
 
 if [ "${DEBUG}" == "true" ]; then
@@ -31,12 +30,6 @@ if [[ $# -gt 0 ]]; then
     ;;
   esac
 fi
-
-log () {
-  if [ "${VERBOSE}" == "true" ]; then
-    echo "${*}"
-  fi
-}
 
 declare -a env_vars
 mapfile -t env_vars < <(sed -E \
@@ -69,7 +62,7 @@ for template in "${templates[@]}"; do
       echo "OK" >&2
     fi
   else
-    log "compiling '${template}' to '${output_file}'"
+    echo >&2 "compiling '${template}' to '${output_file}'"
     envsubst "${ENV_VARS_STRING}" < "${template}" > "${output_file}"
   fi
 done


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes. This script is currently linux only. To run on another platform
   run the docker.sh script; example: ./tools/docker.sh ./tools/compile_templates.sh

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes. ./tools/docker.sh ./tools/generate_parameters_markdown.py
   This script is currently linux only. To run on another platform run the docker.sh script;
   example: ./tools/docker.sh ./tools/generate_parameters_markdown.py

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

We generally want information about what's going on. Let's reduce the
number of knobs for simplicity.