### PR TITLE
Make the PR creation script usable again.

### DIFF
--- a/tools/create_operators_pull_request.py
+++ b/tools/create_operators_pull_request.py
@@ -224,7 +224,7 @@ def commit_copied_operator_files_and_push_branch(
         return rc, f"stdout:\n{stdout}\nstderr:\n{stderr}"
 
     rc, stdout, stderr = run(
-        f"git -C {operators_directory} commit -am '{git_commit_message}'",
+        f"git -C {operators_directory} commit -s -am '{git_commit_message}'",
         debug=debug,
     )
     if rc != 0:

--- a/tools/create_operators_pull_request.py
+++ b/tools/create_operators_pull_request.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 
 from utils import (
+    RELEASE_TAG_PATTERN,
     run,
     get_git_version,
     get_git_user,
@@ -21,7 +22,6 @@ from utils import (
     configure_git_user,
     create_pull_request,
 )
-from release import RELEASE_TAG_PATTERN
 
 PROGRAM_NAME = os.path.basename(__file__)
 

--- a/tools/create_operators_pull_request.py
+++ b/tools/create_operators_pull_request.py
@@ -74,6 +74,12 @@ def parse_arguments() -> argparse.Namespace:
         + "This will also be the PR title",
     )
     parser.add_argument(
+        "--trailer",
+        type=str,
+        nargs="+",
+        help="A trailer to append to the end of git commit message. See https://git-scm.com/docs/git-interpret-trailers"
+    )
+    parser.add_argument(
         "--operators-base-branch",
         type=str,
         default="master",
@@ -372,6 +378,9 @@ def main() -> int:
             if rc != 0:
                 log.error(error_message)
                 return rc
+
+        if args.trailer:
+            git_commit_message_body += "\n\n" + "\n".join(args.trailer)
 
         git_commit_message = (
             f"{git_commit_message_subject}\n\n{git_commit_message_body}"

--- a/tools/create_operators_pull_request.py
+++ b/tools/create_operators_pull_request.py
@@ -74,12 +74,6 @@ def parse_arguments() -> argparse.Namespace:
         + "This will also be the PR title",
     )
     parser.add_argument(
-        "--trailer",
-        type=str,
-        nargs="+",
-        help="A trailer to append to the end of git commit message. See https://git-scm.com/docs/git-interpret-trailers"
-    )
-    parser.add_argument(
         "--operators-base-branch",
         type=str,
         default="master",
@@ -378,9 +372,6 @@ def main() -> int:
             if rc != 0:
                 log.error(error_message)
                 return rc
-
-        if args.trailer:
-            git_commit_message_body += "\n\n" + "\n".join(args.trailer)
 
         git_commit_message = (
             f"{git_commit_message_subject}\n\n{git_commit_message_body}"

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -9,8 +9,34 @@ import http.client
 import json
 import logging
 import os.path as path
+import re
 import subprocess
 import uuid
+
+SEMVER_MAJOR_MINOR_PATTERN = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)")
+
+# https://regex101.com/r/vkijKf/1/
+SEMVER_PATTERN = re.compile(
+    r"(0|[1-9]\d*)"
+    r"\.(0|[1-9]\d*)"
+    r"\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+)
+
+OPERATOR_VERSION_PATTERN = SEMVER_PATTERN
+
+# Assuming APP_VERSION follows SemVer for now.
+APP_VERSION_PATTERN = SEMVER_PATTERN
+
+# Assuming APP_VERSION follows SemVer for now.
+APP_VERSION_MAJOR_MINOR_PATTERN = SEMVER_MAJOR_MINOR_PATTERN
+
+VERSION_PATTERN = re.compile(
+    f"{APP_VERSION_PATTERN.pattern}-{OPERATOR_VERSION_PATTERN.pattern}"
+)
+
+RELEASE_TAG_PATTERN = re.compile(f"v{VERSION_PATTERN.pattern}")
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
- fix broken imports
- add a signed-off-by header to make DCO check happy

<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes. This script is currently linux only. To run on another platform
   run the docker.sh script; example: ./tools/docker.sh ./tools/compile_templates.sh

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes. ./tools/docker.sh ./tools/generate_parameters_markdown.py
   This script is currently linux only. To run on another platform run the docker.sh script;
   example: ./tools/docker.sh ./tools/generate_parameters_markdown.py

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->