### PR TITLE
Fix KUDO version usage in tests

### DIFF
--- a/kuttl-tests/Makefile
+++ b/kuttl-tests/Makefile
@@ -1,68 +1,10 @@
-KUDO_VERSION=0.15.0-rc1
-KUTTL_VERSION=0.5.0
-KUBERNETES_VERSION=1.18.4
-KIND_VERSION=0.8.1
-
-OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
-KUDO_MACHINE=$(shell uname -m)
-MACHINE=$(shell uname -m)
-ifeq "$(MACHINE)" "x86_64"
-  MACHINE=amd64
-endif
-
-export PATH := $(shell pwd)/bin:$(PATH)
-export ROOT_DIR=$(realpath -L ./..)
-export DOCKER_API_VERSION=1.39
-
-ARTIFACTS=kuttl-dist
-
 .PHONY: lint
 lint:
 	golangci-lint run
 
-bin/kubectl_$(KUBERNETES_VERSION)_$(OS):
-	mkdir -p bin/
-	curl -Lo bin/kubectl_$(KUBERNETES_VERSION)_$(OS) https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/$(OS)/$(MACHINE)/kubectl
-	chmod +x bin/kubectl_$(KUBERNETES_VERSION)_$(OS)
-
-bin/kubectl: bin/kubectl_$(KUBERNETES_VERSION)_$(OS)
-	ln -sf ./kubectl_$(KUBERNETES_VERSION)_$(OS) ./bin/kubectl
-
-bin/kubectl-kuttl_$(KUTTL_VERSION)_$(OS):
-	mkdir -p bin/
-	curl -Lo bin/kubectl-kuttl_$(KUTTL_VERSION)_$(OS) https://github.com/kudobuilder/kuttl/releases/download/v$(KUTTL_VERSION)/kubectl-kuttl_$(KUTTL_VERSION)_$(OS)_$(KUDO_MACHINE)
-	chmod +x bin/kubectl-kuttl_$(KUTTL_VERSION)_$(OS)
-
-bin/kubectl-kuttl: bin/kubectl-kuttl_$(KUTTL_VERSION)_$(OS)
-	echo "Linking kubectl-kuttl_$(KUTTL_VERSION)_$(OS)"
-	ln -sf ./kubectl-kuttl_$(KUTTL_VERSION)_$(OS) ./bin/kubectl-kuttl
-
-bin/kubectl-kudo_$(KUDO_VERSION)_$(OS):
-	mkdir -p bin/
-	curl -Lo bin/kubectl-kudo_$(KUDO_VERSION)_$(OS) https://github.com/kudobuilder/kudo/releases/download/v$(KUDO_VERSION)/kubectl-kudo_$(KUDO_VERSION)_$(OS)_$(KUDO_MACHINE)
-	chmod +x bin/kubectl-kudo_$(KUDO_VERSION)_$(OS)
-
-bin/kubectl-kudo: bin/kubectl-kudo_$(KUDO_VERSION)_$(OS)
-	ln -sf ./kubectl-kudo_$(KUDO_VERSION)_$(OS) ./bin/kubectl-kudo
-
-bin/kind_$(KIND_VERSION)_$(OS):
-	mkdir -p bin/
-	curl -Lo bin/kind_$(KIND_VERSION)_$(OS) https://github.com/kubernetes-sigs/kind/releases/download/v$(KIND_VERSION)/kind-$(OS)-$(MACHINE)
-	chmod +x bin/kind_$(KIND_VERSION)_$(OS)
-
-bin/kind: bin/kind_$(KIND_VERSION)_$(OS)
-	ln -sf ./kind_$(KIND_VERSION)_$(OS) ./bin/kind
-
-.PHONY: install-kuttl
-install-kuttl: bin/kubectl-kuttl bin/kubectl-kudo bin/kubectl bin/kind
-
 .PHONY: kind-test
-kind-test: install-kuttl render-test-templates
-	mkdir -p kuttl-dist/
-	go get github.com/jstemmer/go-junit-report
-	kind delete cluster
-	kubectl kuttl test --config=./suites/kuttl-common.yaml --artifacts-dir=$(ARTIFACTS) 2>&1 |tee /dev/fd/2 | go-junit-report -set-exit-code > kuttl-dist/common-junit.xml
-	kubectl kuttl test --config=./suites/kuttl-failure-recovery.yaml --artifacts-dir=$(ARTIFACTS) 2>&1 |tee /dev/fd/2 | go-junit-report -set-exit-code > kuttl-dist/failure-recovery-junit.xml
+kind-test:
+	./kind-test.sh
 
 .PHONY: clean
 clean:

--- a/kuttl-tests/Makefile
+++ b/kuttl-tests/Makefile
@@ -3,7 +3,7 @@ lint:
 	golangci-lint run
 
 .PHONY: kind-test
-kind-test:
+kind-test: render-test-templates
 	./kind-test.sh
 
 .PHONY: clean

--- a/kuttl-tests/kind-test.sh
+++ b/kuttl-tests/kind-test.sh
@@ -15,10 +15,10 @@ KIND_VERSION=0.8.1
 
 ARTIFACTS=kuttl-dist
 
-OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
-KUDO_MACHINE=$(shell uname -m)
-MACHINE=$(shell uname -m)
-ifeq "$(MACHINE)" "x86_64"
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+KUDO_MACHINE=$(uname -m)
+MACHINE=$(uname -m)
+ifeq "${MACHINE}" "x86_64"
   MACHINE=amd64
 endif
 

--- a/kuttl-tests/kind-test.sh
+++ b/kuttl-tests/kind-test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+readonly script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+readonly project_directory="$(readlink -f "${script_directory}/..")"
+
+# shellcheck source=../metadata.sh
+source "${project_directory}/metadata.sh"
+
+KUBECTL_VERSION=1.18.4
+KUTTL_VERSION=0.5.0
+KUBECTL_KUDO_VERSION=${DS_KUDO_VERSION#v}
+KIND_VERSION=0.8.1
+
+ARTIFACTS=kuttl-dist
+
+OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
+KUDO_MACHINE=$(shell uname -m)
+MACHINE=$(shell uname -m)
+ifeq "$(MACHINE)" "x86_64"
+  MACHINE=amd64
+endif
+
+mkdir -p bin/
+
+curl -Lo "bin/kubectl_${KUBECTL_VERSION}_${OS}" "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${OS}/${MACHINE}/kubectl"
+chmod +x "bin/kubectl_${KUBECTL_VERSION}_${OS}"
+ln -sf "bin/kubectl_${KUBECTL_VERSION}_${OS}" bin/kubectl
+
+curl -Lo "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}" "https://github.com/kudobuilder/kuttl/releases/download/v${KUTTL_VERSION}/kubectl-kuttl_${KUTTL_VERSION}_${OS}_${KUDO_MACHINE}"
+chmod +x "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}"
+ln -sf "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}" bin/kubectl-kuttl
+
+curl -Lo "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}" "https://github.com/kudobuilder/kudo/releases/download/v${KUBECTL_KUDO_VERSION}/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}_${KUDO_MACHINE}"
+chmod +x "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}"
+ln -sf "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}" bin/kubectl-kudo
+
+curl -Lo "bin/kind_${KIND_VERSION}_${OS}" "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${OS}-${MACHINE}"
+chmod +x "bin/kind_${KIND_VERSION}_${OS}"
+ln -sf "bin/kind_${KIND_VERSION}_${OS}" bin/kind
+
+mkdir -p $ARTIFACTS
+go get github.com/jstemmer/go-junit-report
+kubectl kuttl test --config=./suites/kuttl-common.yaml --artifacts-dir=${ARTIFACTS} 2>&1 | tee /dev/fd/2 | go-junit-report -set-exit-code > kuttl-dist/common-junit.xml
+kubectl kuttl test --config=./suites/kuttl-failure-recovery.yaml --artifacts-dir=${ARTIFACTS} 2>&1 | tee /dev/fd/2 | go-junit-report -set-exit-code > kuttl-dist/failure-recovery-junit.xml

--- a/kuttl-tests/kind-test.sh
+++ b/kuttl-tests/kind-test.sh
@@ -18,9 +18,9 @@ ARTIFACTS=kuttl-dist
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 KUDO_MACHINE=$(uname -m)
 MACHINE=$(uname -m)
-ifeq "${MACHINE}" "x86_64"
+if [ "${MACHINE}" == "x86_64" ]; then
   MACHINE=amd64
-endif
+fi
 
 mkdir -p bin/
 

--- a/kuttl-tests/kind-test.sh
+++ b/kuttl-tests/kind-test.sh
@@ -24,20 +24,28 @@ fi
 
 mkdir -p bin/
 
-curl -Lo "bin/kubectl_${KUBECTL_VERSION}_${OS}" "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${OS}/${MACHINE}/kubectl"
-chmod +x "bin/kubectl_${KUBECTL_VERSION}_${OS}"
+if [ ! -f "bin/kubectl_${KUBECTL_VERSION}_${OS}" ]; then
+	curl -Lo "bin/kubectl_${KUBECTL_VERSION}_${OS}" "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${OS}/${MACHINE}/kubectl"
+	chmod +x "bin/kubectl_${KUBECTL_VERSION}_${OS}"
+fi
 ln -sf "./kubectl_${KUBECTL_VERSION}_${OS}" ./bin/kubectl
 
-curl -Lo "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}" "https://github.com/kudobuilder/kuttl/releases/download/v${KUTTL_VERSION}/kubectl-kuttl_${KUTTL_VERSION}_${OS}_${KUDO_MACHINE}"
-chmod +x "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}"
+if [ ! -f "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}" ]; then
+	curl -Lo "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}" "https://github.com/kudobuilder/kuttl/releases/download/v${KUTTL_VERSION}/kubectl-kuttl_${KUTTL_VERSION}_${OS}_${KUDO_MACHINE}"
+	chmod +x "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}"
+fi
 ln -sf "./kubectl-kuttl_${KUTTL_VERSION}_${OS}" ./bin/kubectl-kuttl
 
-curl -Lo "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}" "https://github.com/kudobuilder/kudo/releases/download/v${KUBECTL_KUDO_VERSION}/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}_${KUDO_MACHINE}"
-chmod +x "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}"
+if [ ! -f "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}" ]; then
+	curl -Lo "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}" "https://github.com/kudobuilder/kudo/releases/download/v${KUBECTL_KUDO_VERSION}/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}_${KUDO_MACHINE}"
+	chmod +x "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}"
+fi
 ln -sf "./kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}" ./bin/kubectl-kudo
 
-curl -Lo "bin/kind_${KIND_VERSION}_${OS}" "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${OS}-${MACHINE}"
-chmod +x "bin/kind_${KIND_VERSION}_${OS}"
+if [ ! -f "bin/kind_${KIND_VERSION}_${OS}" ]; then
+	curl -Lo "bin/kind_${KIND_VERSION}_${OS}" "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${OS}-${MACHINE}"
+	chmod +x "bin/kind_${KIND_VERSION}_${OS}"
+fi
 ln -sf "./kind_${KIND_VERSION}_${OS}" ./bin/kind
 
 mkdir -p $ARTIFACTS

--- a/kuttl-tests/kind-test.sh
+++ b/kuttl-tests/kind-test.sh
@@ -26,21 +26,23 @@ mkdir -p bin/
 
 curl -Lo "bin/kubectl_${KUBECTL_VERSION}_${OS}" "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${OS}/${MACHINE}/kubectl"
 chmod +x "bin/kubectl_${KUBECTL_VERSION}_${OS}"
-ln -sf "bin/kubectl_${KUBECTL_VERSION}_${OS}" bin/kubectl
+ln -sf "./kubectl_${KUBECTL_VERSION}_${OS}" ./bin/kubectl
 
 curl -Lo "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}" "https://github.com/kudobuilder/kuttl/releases/download/v${KUTTL_VERSION}/kubectl-kuttl_${KUTTL_VERSION}_${OS}_${KUDO_MACHINE}"
 chmod +x "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}"
-ln -sf "bin/kubectl-kuttl_${KUTTL_VERSION}_${OS}" bin/kubectl-kuttl
+ln -sf "./kubectl-kuttl_${KUTTL_VERSION}_${OS}" ./bin/kubectl-kuttl
 
 curl -Lo "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}" "https://github.com/kudobuilder/kudo/releases/download/v${KUBECTL_KUDO_VERSION}/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}_${KUDO_MACHINE}"
 chmod +x "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}"
-ln -sf "bin/kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}" bin/kubectl-kudo
+ln -sf "./kubectl-kudo_${KUBECTL_KUDO_VERSION}_${OS}" ./bin/kubectl-kudo
 
 curl -Lo "bin/kind_${KIND_VERSION}_${OS}" "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${OS}-${MACHINE}"
 chmod +x "bin/kind_${KIND_VERSION}_${OS}"
-ln -sf "bin/kind_${KIND_VERSION}_${OS}" bin/kind
+ln -sf "./kind_${KIND_VERSION}_${OS}" ./bin/kind
 
 mkdir -p $ARTIFACTS
 go get github.com/jstemmer/go-junit-report
+
+PATH="$(pwd)/bin:${PATH}"
 kubectl kuttl test --config=./suites/kuttl-common.yaml --artifacts-dir=${ARTIFACTS} 2>&1 | tee /dev/fd/2 | go-junit-report -set-exit-code > kuttl-dist/common-junit.xml
 kubectl kuttl test --config=./suites/kuttl-failure-recovery.yaml --artifacts-dir=${ARTIFACTS} 2>&1 | tee /dev/fd/2 | go-junit-report -set-exit-code > kuttl-dist/failure-recovery-junit.xml

--- a/run-pre-checks.sh
+++ b/run-pre-checks.sh
@@ -38,6 +38,8 @@ docker run \
 mkdir -p "${artifacts_directory}"/kuttl-dist
 echo "Saving KUTTL artifacts to ${artifacts_directory}/kuttl-dist"
 
+# Note: DS_KUDO_VERSION is used by the shared data-services-kudo tooling.
+
 # run KUTTL tests in ./kuttl-tests directory
 docker run \
   --rm \
@@ -45,6 +47,7 @@ docker run \
   -v "${artifacts_directory}/kuttl-dist:${project_directory}/kuttl-tests/kuttl-dist" \
   -w "${project_directory}"/kuttl-tests \
   --env-file <(env | grep BUILD_VCS_NUMBER_) \
+  -e "DS_KUDO_VERSION=${DS_KUDO_VERSION}" \
   --privileged --network host -v /var/run/docker.sock:/var/run/docker.sock \
   "${INTEGRATION_TESTS_DOCKER_IMAGE}" \
   bash -c "make kind-test"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -33,7 +33,7 @@ docker run \
        --rm \
        -e "KUBECONFIG=${container_kubeconfig}" \
        -e "KUBECTL_PATH=${container_vendor_directory}/kubectl.sh"  \
-       -e "DS_KUDO_VERSION=v${KUDO_VERSION}" \
+       -e "DS_KUDO_VERSION=${DS_KUDO_VERSION}" \
        -e "OPERATOR_DIRECTORY=${container_operator_directory}" \
        -e "VENDOR_DIRECTORY=${container_vendor_directory}" \
        -e "IMAGE_DISAMBIGUATION_SUFFIX=${IMAGE_DISAMBIGUATION_SUFFIX:-}" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,11 +10,8 @@ source "${project_directory}/metadata.sh"
 
 # Note: the following environment variables are required by the shared
 # data-services-kudo tooling.
-export DS_KUDO_VERSION="${DS_KUDO_VERSION:-v${KUDO_VERSION}}"
 export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
 export KUBECTL_PATH="${KUBECTL_PATH:-${VENDOR_DIRECTORY}/kubectl.sh}"
-export OPERATOR_DIRECTORY="${OPERATOR_DIRECTORY:-${project_directory}/operator}"
-export VENDOR_DIRECTORY="${VENDOR_DIRECTORY:-${project_directory}/shared/vendor}"
 
 # Tests that take longer than this in seconds are marked as slow
 export GINKO_SLOW_TEST_THRESHOLD=240


### PR DESCRIPTION
The DS_KUDO_VERSION parameter wasn't honored by 'run-pre-checks.sh' and 'run-tests.sh'. This has been fixed. Most of the functionality of 'kuttl-tests/Makefile' has been extracted into a shell script that uses 'metadata.sh'.
Also removes some redundancies in the scripts.

Fixes #160
<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes. This script is currently linux only. To run on another platform
   run the docker.sh script; example: ./tools/docker.sh ./tools/compile_templates.sh

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes. ./tools/docker.sh ./tools/generate_parameters_markdown.py
   This script is currently linux only. To run on another platform run the docker.sh script;
   example: ./tools/docker.sh ./tools/generate_parameters_markdown.py

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
