### PR TITLE
Add OpenSSL and zlib to Medusa Docker images

### DIFF
--- a/images/Dockerfile.medusa-backup
+++ b/images/Dockerfile.medusa-backup
@@ -6,7 +6,7 @@ ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
 RUN apt-get update; \
-    apt-get install -y --no-install-recommends sudo libc6-dev libev-dev gcc make cmake python3-dev python3-pip groff vim; \
+    apt-get install -y --no-install-recommends sudo libc6-dev libev-dev gcc make cmake python3-dev python3-pip openssl libssl-dev zlib1g-dev groff vim; \
     sudo pip3 install setuptools wheel; \
     sudo pip3 install awscli cassandra-medusa[S3]==0.6.0
 

--- a/templates/images/Dockerfile.medusa-backup.template
+++ b/templates/images/Dockerfile.medusa-backup.template
@@ -6,7 +6,7 @@ ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
 RUN apt-get update; \
-    apt-get install -y --no-install-recommends sudo libc6-dev libev-dev gcc make cmake python3-dev python3-pip openssl libssl-dev groff vim; \
+    apt-get install -y --no-install-recommends sudo libc6-dev libev-dev gcc make cmake python3-dev python3-pip openssl libssl-dev zlib1g-dev groff vim; \
     sudo pip3 install setuptools wheel; \
     sudo pip3 install awscli cassandra-medusa[S3]==${MEDUSA_BACKUP_VERSION}
 

--- a/templates/images/Dockerfile.medusa-backup.template
+++ b/templates/images/Dockerfile.medusa-backup.template
@@ -6,7 +6,7 @@ ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
 RUN apt-get update; \
-    apt-get install -y --no-install-recommends sudo libc6-dev libev-dev gcc make cmake python3-dev python3-pip groff vim; \
+    apt-get install -y --no-install-recommends sudo libc6-dev libev-dev gcc make cmake python3-dev python3-pip openssl libssl-dev groff vim; \
     sudo pip3 install setuptools wheel; \
     sudo pip3 install awscli cassandra-medusa[S3]==${MEDUSA_BACKUP_VERSION}
 


### PR DESCRIPTION
'cassandra-medusa' depends on 'ssh2-python' which needs OpenSSL & zlib library and headers.

<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes. This script is currently linux only. To run on another platform
   run the docker.sh script; example: ./tools/docker.sh ./tools/compile_templates.sh

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes. ./tools/docker.sh ./tools/generate_parameters_markdown.py
   This script is currently linux only. To run on another platform run the docker.sh script;
   example: ./tools/docker.sh ./tools/generate_parameters_markdown.py

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
