### PR TITLE
Introduce a parameter to set annotations for the external service

### DIFF
--- a/docs/accessing.md
+++ b/docs/accessing.md
@@ -129,6 +129,7 @@ Cassandra nodes. There are the following options:
   the native transport port on the nodes
 - EXTERNAL_RPC_PORT="9160" The external port that is forwarded to the rpc port
   on the nodes
+- EXTERNAL_SERVICE_ANNOTATIONS Annotations that are added to the external service. E.g., this can be used to configure ExternalDNS access
 
 :warning: The external service definition will at the moment not be deleted if
 you set EXTERNAL_NATIVE_TRANSPORT and EXTERNAL_RPC to "false". If you need to

--- a/docs/accessing.md
+++ b/docs/accessing.md
@@ -129,8 +129,18 @@ Cassandra nodes. There are the following options:
   the native transport port on the nodes
 - EXTERNAL_RPC_PORT="9160" The external port that is forwarded to the rpc port
   on the nodes
-- EXTERNAL_SERVICE_ANNOTATIONS Annotations that are added to the external service. E.g., this can be used to configure ExternalDNS access
+- EXTERNAL_SERVICE_ANNOTATIONS Annotations that are added to the external
+  service. E.g., this can be used to configure ExternalDNS access
 
 :warning: The external service definition will at the moment not be deleted if
 you set EXTERNAL_NATIVE_TRANSPORT and EXTERNAL_RPC to "false". If you need to
 remove external access, you have to remove the external service manually.
+
+### ExternalDNS annotations
+
+The EXTERNAL_SERVICE_ANNOTATIONS parameter can be used to set up ExternalDNS
+access when the external service is enabled. For example, one can set
+
+```
+EXTERNAL_SERVICE_ANNOTATIONS={"external-dns.alpha.kubernetes.io/hostname": "cassandra.example.org"}
+```

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -117,6 +117,7 @@ Allow access to the Cassandra Cluster from outside Kubernetes.
 | **EXTERNAL_RPC**                   | This exposes the Cassandra cluster via an external service so it can be accessed from outside the Kubernetes cluster. Works only if START_RPC is true. | False   |
 | **EXTERNAL_NATIVE_TRANSPORT_PORT** | The external port to use for Cassandra native transport protocol.                                                                                      | 9042    |
 | **EXTERNAL_RPC_PORT**              | The external port to use for Cassandra rpc protocol.                                                                                                   | 9160    |
+| **EXTERNAL_SERVICE_ANNOTATIONS**   | Custom annotations for the external service.                                                                                                           |         |
 
 ## <a name="metrics"></a> Metrics Export
 

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -338,6 +338,14 @@ parameters:
     default: "9160"
     group: external
 
+  - name: EXTERNAL_SERVICE_ANNOTATIONS
+    displayName: "External service annotations"
+    hint: "Annotations added to the external service."
+    type: map
+    description: "Custom annotations for the external service."
+    default:
+    group: external
+
   - name: BOOTSTRAP_TIMEOUT
     displayName: "Bootstrap Timeout"
     type: string

--- a/operator/params.yaml
+++ b/operator/params.yaml
@@ -340,7 +340,7 @@ parameters:
 
   - name: EXTERNAL_SERVICE_ANNOTATIONS
     displayName: "External service annotations"
-    hint: "Annotations added to the external service."
+    hint: "Key-Value Pairs of annotations."
     type: map
     description: "Custom annotations for the external service."
     default:

--- a/operator/templates/external-service.yaml
+++ b/operator/templates/external-service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: {{ .Name }}-svc-external
   namespace: {{ .Namespace }}
+  annotations:
+    {{ toYaml .Params.EXTERNAL_SERVICE_ANNOTATIONS }}
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/templates/operator/params.yaml.template
+++ b/templates/operator/params.yaml.template
@@ -338,6 +338,14 @@ parameters:
     default: "9160"
     group: external
 
+  - name: EXTERNAL_SERVICE_ANNOTATIONS
+    displayName: "External service annotations"
+    hint: "Annotations added to the external service."
+    type: map
+    description: "Custom annotations for the external service."
+    default:
+    group: external
+
   - name: BOOTSTRAP_TIMEOUT
     displayName: "Bootstrap Timeout"
     type: string

--- a/templates/operator/params.yaml.template
+++ b/templates/operator/params.yaml.template
@@ -340,7 +340,7 @@ parameters:
 
   - name: EXTERNAL_SERVICE_ANNOTATIONS
     displayName: "External service annotations"
-    hint: "Annotations added to the external service."
+    hint: "Key-Value Pairs of annotations."
     type: map
     description: "Custom annotations for the external service."
     default:


### PR DESCRIPTION
ExternalDNS access is enabled by adding `external-dns.alpha.kubernetes.io/*` annotations to services. This can be done using the `EXTERNAL_SERVICE_ANNOTATIONS` parameter.

<!--
Thanks for sending a pull request! Here are some tips:

1. Please make yourself familiar with the general development guidelines:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#development

2. Please make sure that the PR abides to the style guide:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/DEVELOPMENT.md#style-guide

3. Please make sure that that `git status` looks clean after running
   `./tools/compile_templates.sh`. If there's a diff you might need to commit
   further changes. This script is currently linux only. To run on another platform
   run the docker.sh script; example: ./tools/docker.sh ./tools/compile_templates.sh

4. Please make sure that that `git status` looks clean after running
   `./tools/generate_parameters_markdown.py`. If there's a diff you might need
   to commit further changes. ./tools/docker.sh ./tools/generate_parameters_markdown.py
   This script is currently linux only. To run on another platform run the docker.sh script;
   example: ./tools/docker.sh ./tools/generate_parameters_markdown.py

5. Please make sure that that `git status` looks clean after running
   `./tools/format_files.sh`. If there's a diff you might need to commit further
   changes.

6. If it makes sense, please add an entry to the CHANGELOG:
   https://github.com/mesosphere/kudo-cassandra-operator/blob/master/CHANGELOG.md#unreleased

7. If the PR is unfinished, please start it as a Draft PR:
   https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
