### PR TITLE
[D2IQ-73245] Adds awscli in docker image to support Schema and Data Migration

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -9,7 +9,7 @@ FROM cassandra:3.11.7
 
 RUN set -eux; \
   apt-get update; \
-  apt-get install -y --no-install-recommends libcap2-bin jq; \
+  apt-get install -y --no-install-recommends libcap2-bin jq awscli; \
   curl -Lo /etc/jolokia.tar.gz https://github.com/rhuss/jolokia/releases/download/v1.6.2/jolokia-1.6.2-bin.tar.gz; \
   tar xvfz /etc/jolokia.tar.gz; \
   mv jolokia-1.6.2/agents/jolokia-jvm.jar /etc/jolokia-agent.jar; \


### PR DESCRIPTION
Jira Tickets: [D2IQ-73245](https://jira.d2iq.com/browse/D2IQ-73245) and [D2IQ-73246](https://jira.d2iq.com/browse/D2IQ-73246)

### What changes?
- Adds `awscli` in docker image of cassandra to support AWS commands in the pod

### Why changes required?
DC/OS Cassandra supports S3 to store backup. To migrate schema and data to KUDO Cassandra using S3, we need `awscli` to be available in the PODs.